### PR TITLE
Making statusMessage optional

### DIFF
--- a/toolkits/ob-apim/repository/resources/wso2am-4.2.0-deployment-cds.toml
+++ b/toolkits/ob-apim/repository/resources/wso2am-4.2.0-deployment-cds.toml
@@ -643,7 +643,7 @@ type="int"
 [[open_banking.data_publishing.thrift.stream.attributes]]
 name="statusMessage"
 priority=7
-required=true
+required=false
 [[open_banking.data_publishing.thrift.stream.attributes]]
 name="httpMethod"
 priority=8

--- a/toolkits/ob-is/repository/resources/wso2is-6.0.0-deployment-cds.toml
+++ b/toolkits/ob-is/repository/resources/wso2is-6.0.0-deployment-cds.toml
@@ -605,7 +605,7 @@ type="int"
 [[open_banking.data_publishing.thrift.stream.attributes]]
 name="statusMessage"
 priority=7
-required=true
+required=false
 [[open_banking.data_publishing.thrift.stream.attributes]]
 name="httpMethod"
 priority=8


### PR DESCRIPTION
## Making statusMessage optional

> Making statusMessage optional since, statusMessage is only used in error scenarios.

**Issue link:**

- https://github.com/wso2/financial-services-accelerator/issues/142

**Applicable Labels:** OB3 CDS Toolkit

------

### Development Checklist

1. [X] Built complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?


## Resources

**Knowledge Base:** https://sites.google.com/wso2.com/open-banking/

**Guides:** https://sites.google.com/wso2.com/open-banking/developer-guides
