### PR TITLE
Added separate executor list to handle CDS unauthenticated endpoints

### DIFF
--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouter.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouter.java
@@ -22,6 +22,7 @@ import com.wso2.openbanking.accelerator.gateway.executor.core.AbstractRequestRou
 import com.wso2.openbanking.accelerator.gateway.executor.core.OpenBankingGatewayExecutor;
 import com.wso2.openbanking.accelerator.gateway.executor.model.OBAPIRequestContext;
 import com.wso2.openbanking.accelerator.gateway.executor.model.OBAPIResponseContext;
+import org.wso2.openbanking.cds.gateway.utils.GatewayConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +47,7 @@ public class CDSAPIRequestRouter extends AbstractRequestRouter {
             requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
                     RequestRouterConstants.API_TYPE_NON_REGULATORY);
             return EMPTY_LIST;
-        } else if (RequestRouterConstants.CDS_UNAUTHENTICATED_ELECTED_RESOURCES.contains(requestContext.getMsgInfo()
+        } else if (GatewayConstants.UNAUTHENTICATED_ENDPOINTS.contains(requestContext.getMsgInfo()
                 .getElectedResource())) {
             requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
                     RequestRouterConstants.API_TYPE_CDS_UNAUTHENTICATED);

--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouter.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouter.java
@@ -46,6 +46,11 @@ public class CDSAPIRequestRouter extends AbstractRequestRouter {
             requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
                     RequestRouterConstants.API_TYPE_NON_REGULATORY);
             return EMPTY_LIST;
+        } else if (RequestRouterConstants.CDS_UNAUTHENTICATED_ELECTED_RESOURCES.contains(requestContext.getMsgInfo()
+                .getElectedResource())) {
+            requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
+                    RequestRouterConstants.API_TYPE_CDS_UNAUTHENTICATED);
+            return this.getExecutorMap().get(RequestRouterConstants.CDS_UNAUTHENTICATED);
         } else if (RequestRouterConstants.API_TYPE_CONSENT
                 .equals(requestContext.getOpenAPI().getExtensions().get(RequestRouterConstants.API_TYPE_CUSTOM_PROP))) {
             // Add support for consent management portal APIs
@@ -104,6 +109,9 @@ public class CDSAPIRequestRouter extends AbstractRequestRouter {
                     break;
                 case RequestRouterConstants.API_TYPE_CDS:
                     executorList = this.getExecutorMap().get(RequestRouterConstants.CDS);
+                    break;
+                case RequestRouterConstants.API_TYPE_CDS_UNAUTHENTICATED:
+                    executorList = this.getExecutorMap().get(RequestRouterConstants.CDS_UNAUTHENTICATED);
                     break;
                 case RequestRouterConstants.API_TYPE_COMMON:
                     executorList = this.getExecutorMap().get(RequestRouterConstants.CDS_COMMON);

--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouter.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouter.java
@@ -52,6 +52,11 @@ public class CDSAPIRequestRouter extends AbstractRequestRouter {
             requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
                     RequestRouterConstants.API_TYPE_CDS_UNAUTHENTICATED);
             return this.getExecutorMap().get(RequestRouterConstants.CDS_UNAUTHENTICATED);
+        } else if (GatewayConstants.COMMON_ENDPOINTS.contains(requestContext.getMsgInfo()
+                .getElectedResource())) {
+            requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
+                    RequestRouterConstants.API_TYPE_COMMON);
+            return this.getExecutorMap().get(RequestRouterConstants.CDS_COMMON);
         } else if (RequestRouterConstants.API_TYPE_CONSENT
                 .equals(requestContext.getOpenAPI().getExtensions().get(RequestRouterConstants.API_TYPE_CUSTOM_PROP))) {
             // Add support for consent management portal APIs
@@ -67,10 +72,6 @@ public class CDSAPIRequestRouter extends AbstractRequestRouter {
             requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
                     RequestRouterConstants.API_TYPE_CDS);
             return this.getExecutorMap().get(RequestRouterConstants.CDS);
-        } else if (RequestRouterConstants.COMMON_API_NAME.equals(requestContext.getOpenAPI().getInfo().getTitle())) {
-            requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
-                    RequestRouterConstants.API_TYPE_COMMON);
-            return this.getExecutorMap().get(RequestRouterConstants.CDS_COMMON);
         } else if (RequestRouterConstants.ADMIN_API_NAME.equals(requestContext.getOpenAPI().getInfo().getTitle())) {
             requestContext.addContextProperty(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
                     RequestRouterConstants.API_TYPE_ADMIN);

--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/RequestRouterConstants.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/RequestRouterConstants.java
@@ -18,15 +18,22 @@
 
 package org.wso2.openbanking.cds.gateway.executors.core;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Constants required for CDSAPIRequestRouter.
  */
 public class RequestRouterConstants {
 
+    public static final List<String> CDS_UNAUTHENTICATED_ELECTED_RESOURCES = Arrays.asList("/banking/products",
+            "/banking/products/{productId}", "/discovery/status", "/discovery/outages");
+
     // Executor list names
     public static final String DEFAULT = "Default";
     public static final String DCR = "DCR";
     public static final String CDS = "CDS";
+    public static final String CDS_UNAUTHENTICATED = "CDSUnauthenticated";
     public static final String CDS_COMMON = "CDSCommon";
     public static final String CONSENT = "Consent";
     public static final String ADMIN = "Admin";
@@ -38,6 +45,7 @@ public class RequestRouterConstants {
     public static final String API_TYPE_NON_REGULATORY = "non-regulatory";
     public static final String API_TYPE_DCR = "dcr";
     public static final String API_TYPE_CDS = "cds";
+    public static final String API_TYPE_CDS_UNAUTHENTICATED = "cds-unauthenticated";
     public static final String API_TYPE_COMMON = "common";
     public static final String API_TYPE_ARRANGEMENT = "arrangement";
     public static final String API_TYPE_ADMIN = "admin";

--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/RequestRouterConstants.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/executors/core/RequestRouterConstants.java
@@ -18,16 +18,10 @@
 
 package org.wso2.openbanking.cds.gateway.executors.core;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
  * Constants required for CDSAPIRequestRouter.
  */
 public class RequestRouterConstants {
-
-    public static final List<String> CDS_UNAUTHENTICATED_ELECTED_RESOURCES = Arrays.asList("/banking/products",
-            "/banking/products/{productId}", "/discovery/status", "/discovery/outages");
 
     // Executor list names
     public static final String DEFAULT = "Default";

--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/utils/GatewayConstants.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/utils/GatewayConstants.java
@@ -106,6 +106,8 @@ public class GatewayConstants {
     public static final String DISCOVERY_STATUS_ENDPOINT = "/discovery/status";
     public static final String PRODUCTS_ENDPOINT = "/banking/products";
     public static final String PRODUCT_DETAILS_ENDPOINT = "/banking/products/{productId}";
+    public static final String COMMON_CUSTOMER_ENDPOINT = "/common/customer";
+    public static final String COMMON_CUSTOMER_DETAIL_ENDPOINT = "/common/customer/detail";
 
     public static final List<String> INFOSEC_ENDPOINTS = Collections.unmodifiableList(Arrays.asList(AUTHORIZE_ENDPOINT,
             TOKEN_ENDPOINT, USERINFO_ENDPOINT, PAR_ENDPOINT, INTROSPECTION_ENDPOINT, JWKS_ENDPOINT, REVOKE_ENDPOINT,
@@ -114,6 +116,9 @@ public class GatewayConstants {
 
     public static final List<String> UNAUTHENTICATED_ENDPOINTS = Collections.unmodifiableList(Arrays.asList(
             PRODUCTS_ENDPOINT, PRODUCT_DETAILS_ENDPOINT, DISCOVERY_STATUS_ENDPOINT, DISCOVERY_OUTAGES_ENDPOINT));
+
+    public static final List<String> COMMON_ENDPOINTS = Collections.unmodifiableList(Arrays.asList(
+            COMMON_CUSTOMER_ENDPOINT, COMMON_CUSTOMER_DETAIL_ENDPOINT));
 
     public static final String UNKNOWN = "Unknown";
     public static final String CLIENT_USER_AGENT = "User-Agent";

--- a/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/utils/GatewayConstants.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/main/java/org/wso2/openbanking/cds/gateway/utils/GatewayConstants.java
@@ -104,11 +104,16 @@ public class GatewayConstants {
     public static final String CDR_ARRANGEMENT_ENDPOINT = "/{cdrArrangementId}";
     public static final String DISCOVERY_OUTAGES_ENDPOINT = "/discovery/outages";
     public static final String DISCOVERY_STATUS_ENDPOINT = "/discovery/status";
+    public static final String PRODUCTS_ENDPOINT = "/banking/products";
+    public static final String PRODUCT_DETAILS_ENDPOINT = "/banking/products/{productId}";
 
     public static final List<String> INFOSEC_ENDPOINTS = Collections.unmodifiableList(Arrays.asList(AUTHORIZE_ENDPOINT,
             TOKEN_ENDPOINT, USERINFO_ENDPOINT, PAR_ENDPOINT, INTROSPECTION_ENDPOINT, JWKS_ENDPOINT, REVOKE_ENDPOINT,
             REGISTER_ENDPOINT, REGISTER_CLIENT_ID_ENDPOINT, WELL_KNOWN_ENDPOINT, CDR_ARRANGEMENT_ENDPOINT,
             DISCOVERY_OUTAGES_ENDPOINT, DISCOVERY_STATUS_ENDPOINT));
+
+    public static final List<String> UNAUTHENTICATED_ENDPOINTS = Collections.unmodifiableList(Arrays.asList(
+            PRODUCTS_ENDPOINT, PRODUCT_DETAILS_ENDPOINT, DISCOVERY_STATUS_ENDPOINT, DISCOVERY_OUTAGES_ENDPOINT));
 
     public static final String UNKNOWN = "Unknown";
     public static final String CLIENT_USER_AGENT = "User-Agent";

--- a/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouterTest.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouterTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.apimgt.common.gateway.dto.MsgInfoDTO;
 import org.wso2.openbanking.cds.gateway.test.util.TestUtil;
+import org.wso2.openbanking.cds.gateway.utils.GatewayConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -131,5 +132,28 @@ public class CDSAPIRequestRouterTest {
         Mockito.when(obapiResponseContext.getContextProps()).thenReturn(contextProps);
         Assert.assertEquals(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext).size(), 0);
         Assert.assertEquals(cdsApiRequestRouter.getExecutorsForResponse(obapiResponseContext).size(), 0);
+    }
+
+    @Test(priority = 3)
+    public void testUnauthenticatedAPIcall() {
+
+        OBAPIRequestContext obapiRequestContext = Mockito.mock(OBAPIRequestContext.class);
+        OBAPIResponseContext obapiResponseContext = Mockito.mock(OBAPIResponseContext.class);
+        Map<String, Object> extensions = new HashMap<>();
+        Map<String, String> contextProps = new HashMap<>();
+        extensions.put(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
+                RequestRouterConstants.API_TYPE_CDS_UNAUTHENTICATED);
+        contextProps.put(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
+                RequestRouterConstants.API_TYPE_CDS_UNAUTHENTICATED);
+        openAPI.setExtensions(extensions);
+        Mockito.when(obapiRequestContext.getOpenAPI()).thenReturn(openAPI);
+
+        MsgInfoDTO msgInfoDTO = new MsgInfoDTO();
+        msgInfoDTO.setElectedResource(GatewayConstants.PRODUCT_DETAILS_ENDPOINT);
+        Mockito.when(obapiRequestContext.getMsgInfo()).thenReturn(msgInfoDTO);
+
+        Mockito.when(obapiResponseContext.getContextProps()).thenReturn(contextProps);
+        Assert.assertEquals(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext).size(), 1);
+        Assert.assertEquals(cdsApiRequestRouter.getExecutorsForResponse(obapiResponseContext).size(), 1);
     }
 }

--- a/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouterTest.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouterTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.apimgt.common.gateway.dto.MsgInfoDTO;
 import org.wso2.openbanking.cds.gateway.test.util.TestUtil;
 
 import java.util.HashMap;
@@ -60,6 +61,10 @@ public class CDSAPIRequestRouterTest {
         contextProps.put(RequestRouterConstants.API_TYPE_CUSTOM_PROP, RequestRouterConstants.API_TYPE_DCR);
         openAPI.setExtensions(extensions);
         Mockito.when(obapiRequestContext.getOpenAPI()).thenReturn(openAPI);
+
+        MsgInfoDTO msgInfoDTO = new MsgInfoDTO();
+        Mockito.when(obapiRequestContext.getMsgInfo()).thenReturn(msgInfoDTO);
+
         Mockito.when(obapiResponseContext.getContextProps()).thenReturn(contextProps);
         Mockito.when(apiInfo.getTitle()).thenReturn(RequestRouterConstants.DCR_API_NAME);
         Assert.assertNotNull(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext));
@@ -80,6 +85,10 @@ public class CDSAPIRequestRouterTest {
         contextProps.put(RequestRouterConstants.API_TYPE_CUSTOM_PROP, RequestRouterConstants.API_TYPE_CDS);
         openAPI.setExtensions(extensions);
         Mockito.when(obapiRequestContext.getOpenAPI()).thenReturn(openAPI);
+
+        MsgInfoDTO msgInfoDTO = new MsgInfoDTO();
+        Mockito.when(obapiRequestContext.getMsgInfo()).thenReturn(msgInfoDTO);
+
         Mockito.when(obapiResponseContext.getContextProps()).thenReturn(contextProps);
         Mockito.when(apiInfo.getTitle()).thenReturn(RequestRouterConstants.CDS_API_NAME);
         Assert.assertNotNull(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext));
@@ -98,6 +107,10 @@ public class CDSAPIRequestRouterTest {
         Map<String, String> contextProps = new HashMap<>();
         openAPI.setExtensions(extensions);
         Mockito.when(obapiRequestContext.getOpenAPI()).thenReturn(openAPI);
+
+        MsgInfoDTO msgInfoDTO = new MsgInfoDTO();
+        Mockito.when(obapiRequestContext.getMsgInfo()).thenReturn(msgInfoDTO);
+
         Mockito.when(obapiResponseContext.getContextProps()).thenReturn(contextProps);
         Mockito.when(apiInfo.getTitle()).thenReturn(RequestRouterConstants.CDS_API_NAME);
         Assert.assertNotNull(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext));

--- a/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouterTest.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/executors/core/CDSAPIRequestRouterTest.java
@@ -156,4 +156,27 @@ public class CDSAPIRequestRouterTest {
         Assert.assertEquals(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext).size(), 1);
         Assert.assertEquals(cdsApiRequestRouter.getExecutorsForResponse(obapiResponseContext).size(), 1);
     }
+
+    @Test(priority = 3)
+    public void testCommonAPIcall() {
+
+        OBAPIRequestContext obapiRequestContext = Mockito.mock(OBAPIRequestContext.class);
+        OBAPIResponseContext obapiResponseContext = Mockito.mock(OBAPIResponseContext.class);
+        Map<String, Object> extensions = new HashMap<>();
+        Map<String, String> contextProps = new HashMap<>();
+        extensions.put(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
+                RequestRouterConstants.API_TYPE_COMMON);
+        contextProps.put(RequestRouterConstants.API_TYPE_CUSTOM_PROP,
+                RequestRouterConstants.API_TYPE_COMMON);
+        openAPI.setExtensions(extensions);
+        Mockito.when(obapiRequestContext.getOpenAPI()).thenReturn(openAPI);
+
+        MsgInfoDTO msgInfoDTO = new MsgInfoDTO();
+        msgInfoDTO.setElectedResource(GatewayConstants.COMMON_CUSTOMER_ENDPOINT);
+        Mockito.when(obapiRequestContext.getMsgInfo()).thenReturn(msgInfoDTO);
+
+        Mockito.when(obapiResponseContext.getContextProps()).thenReturn(contextProps);
+        Assert.assertEquals(cdsApiRequestRouter.getExecutorsForRequest(obapiRequestContext).size(), 1);
+        Assert.assertEquals(cdsApiRequestRouter.getExecutorsForResponse(obapiResponseContext).size(), 1);
+    }
 }

--- a/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/test/TestConstants.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/test/TestConstants.java
@@ -44,6 +44,7 @@ public class TestConstants {
     public static final Map<String, Map<Integer, String>> FULL_VALIDATOR_MAP = Stream.of(
                     new AbstractMap.SimpleImmutableEntry<>("Default", VALID_EXECUTOR_MAP),
                     new AbstractMap.SimpleImmutableEntry<>("DCR", VALID_EXECUTOR_MAP),
-                    new AbstractMap.SimpleImmutableEntry<>("CDS", VALID_EXECUTOR_MAP))
+                    new AbstractMap.SimpleImmutableEntry<>("CDS", VALID_EXECUTOR_MAP),
+                    new AbstractMap.SimpleImmutableEntry<>("CDSUnauthenticated", VALID_EXECUTOR_MAP))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 }

--- a/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/test/TestConstants.java
+++ b/components/org.wso2.openbanking.cds.gateway/src/test/java/org/wso2/openbanking/cds/gateway/test/TestConstants.java
@@ -45,6 +45,7 @@ public class TestConstants {
                     new AbstractMap.SimpleImmutableEntry<>("Default", VALID_EXECUTOR_MAP),
                     new AbstractMap.SimpleImmutableEntry<>("DCR", VALID_EXECUTOR_MAP),
                     new AbstractMap.SimpleImmutableEntry<>("CDS", VALID_EXECUTOR_MAP),
+                    new AbstractMap.SimpleImmutableEntry<>("CDSCommon", VALID_EXECUTOR_MAP),
                     new AbstractMap.SimpleImmutableEntry<>("CDSUnauthenticated", VALID_EXECUTOR_MAP))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 }

--- a/toolkits/ob-apim/repository/resources/wso2am-4.2.0-deployment-cds.toml
+++ b/toolkits/ob-apim/repository/resources/wso2am-4.2.0-deployment-cds.toml
@@ -533,6 +533,33 @@ name = "org.wso2.openbanking.cds.gateway.executors.error.handler.CDSErrorHandler
 priority = 1000
 
 [[open_banking.gateway.openbanking_gateway_executors.type]]
+name = "CDSUnauthenticated"
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "com.wso2.openbanking.accelerator.gateway.executor.impl.mtls.cert.validation.executor.CertRevocationValidationExecutor"
+priority = 1
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "com.wso2.openbanking.accelerator.gateway.executor.impl.api.resource.access.validation.APIResourceAccessValidationExecutor"
+priority = 2
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "org.wso2.openbanking.cds.gateway.executors.idpermanence.IDPermanenceExecutor"
+priority = 3
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "org.wso2.openbanking.cds.gateway.executors.header.validation.CDSHeaderValidationExecutor"
+priority = 4
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "com.wso2.openbanking.accelerator.gateway.executor.impl.consent.ConsentEnforcementExecutor"
+priority = 5
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "com.wso2.openbanking.accelerator.gateway.executor.impl.common.reporting.data.executor.CommonReportingDataExecutor"
+priority = 6
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "org.wso2.openbanking.cds.gateway.executors.reporting.CDSCommonDataReportingExecutor"
+priority = 7
+[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
+name = "org.wso2.openbanking.cds.gateway.executors.error.handler.CDSErrorHandler"
+priority = 1000
+
+[[open_banking.gateway.openbanking_gateway_executors.type]]
 name = "CDSCommon"
 [[open_banking.gateway.openbanking_gateway_executors.type.executors]]
 name = "com.wso2.openbanking.accelerator.gateway.executor.impl.mtls.cert.validation.executor.MTLSEnforcementExecutor"

--- a/toolkits/ob-apim/repository/resources/wso2am-4.2.0-deployment-cds.toml
+++ b/toolkits/ob-apim/repository/resources/wso2am-4.2.0-deployment-cds.toml
@@ -535,26 +535,17 @@ priority = 1000
 [[open_banking.gateway.openbanking_gateway_executors.type]]
 name = "CDSUnauthenticated"
 [[open_banking.gateway.openbanking_gateway_executors.type.executors]]
-name = "com.wso2.openbanking.accelerator.gateway.executor.impl.mtls.cert.validation.executor.CertRevocationValidationExecutor"
+name = "org.wso2.openbanking.cds.gateway.executors.idpermanence.IDPermanenceExecutor"
 priority = 1
 [[open_banking.gateway.openbanking_gateway_executors.type.executors]]
-name = "com.wso2.openbanking.accelerator.gateway.executor.impl.api.resource.access.validation.APIResourceAccessValidationExecutor"
+name = "org.wso2.openbanking.cds.gateway.executors.header.validation.CDSHeaderValidationExecutor"
 priority = 2
 [[open_banking.gateway.openbanking_gateway_executors.type.executors]]
-name = "org.wso2.openbanking.cds.gateway.executors.idpermanence.IDPermanenceExecutor"
+name = "com.wso2.openbanking.accelerator.gateway.executor.impl.common.reporting.data.executor.CommonReportingDataExecutor"
 priority = 3
 [[open_banking.gateway.openbanking_gateway_executors.type.executors]]
-name = "org.wso2.openbanking.cds.gateway.executors.header.validation.CDSHeaderValidationExecutor"
-priority = 4
-[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
-name = "com.wso2.openbanking.accelerator.gateway.executor.impl.consent.ConsentEnforcementExecutor"
-priority = 5
-[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
-name = "com.wso2.openbanking.accelerator.gateway.executor.impl.common.reporting.data.executor.CommonReportingDataExecutor"
-priority = 6
-[[open_banking.gateway.openbanking_gateway_executors.type.executors]]
 name = "org.wso2.openbanking.cds.gateway.executors.reporting.CDSCommonDataReportingExecutor"
-priority = 7
+priority = 4
 [[open_banking.gateway.openbanking_gateway_executors.type.executors]]
 name = "org.wso2.openbanking.cds.gateway.executors.error.handler.CDSErrorHandler"
 priority = 1000


### PR DESCRIPTION
## Added separate executor list to handle CDS unauthenticated endpoints

> $subject by not engaging the MTLS executor for the following unauthenticated elected resources:
"/banking/products", "/banking/products/{productId}", "/discovery/status", "/discovery/outages"

**Issue link:** 

- https://github.com/wso2-enterprise/wso2-ob-internal/issues/855

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** OB 3.0.0, CDS Toolkit

------

### Development Checklist

1. [ ] Built complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [ ] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).

## Resources

**Knowledge Base:** https://sites.google.com/wso2.com/open-banking/

**Guides:** https://sites.google.com/wso2.com/open-banking/developer-guides
