### PR TITLE
Delete existing old dropins jar before copying the new jar when building the solution

### DIFF
--- a/toolkits/ob-apim/pom.xml
+++ b/toolkits/ob-apim/pom.xml
@@ -90,6 +90,11 @@
                                                 regex="org.wso2.openbanking.cds.gateway-(\d.*?)\.jar$"/>
                                     </fileset>
                                 </copy>
+                                <delete>
+                                    <fileset dir="${project.basedir}/carbon-home/repository/components/dropins">
+                                        <include name="org.wso2.openbanking.cds.metrics-*.jar" />
+                                    </fileset>
+                                </delete>
                                 <copy todir="${project.basedir}/carbon-home/repository/components/dropins" overwrite="true">
                                     <fileset
                                             dir="../../components/org.wso2.openbanking.cds.metrics/target">

--- a/toolkits/ob-is/pom.xml
+++ b/toolkits/ob-is/pom.xml
@@ -67,6 +67,11 @@
                         <phase>package</phase>
                         <configuration>
                             <target>
+                                <delete>
+                                    <fileset dir="${project.basedir}/carbon-home/repository/components/dropins">
+                                        <include name="org.wso2.openbanking.cds.identity-*.jar" />
+                                    </fileset>
+                                </delete>
                                 <!-- Copying jars to lib -->
                                 <copy overwrite="true" todir="${project.basedir}/carbon-home/repository/components/dropins">
                                     <fileset dir="../../components/org.wso2.openbanking.cds.identity/target">


### PR DESCRIPTION
## Delete existing old dropins jar before copying the new jar when building the solution

> $subject

Issue: https://github.com/wso2/financial-services-accelerator/issues/187
