### PR TITLE
Add CDS Policy to Filter SUI-Blocked Accounts from Account Resource API

### DIFF
--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
@@ -27,6 +27,7 @@ import org.apache.synapse.mediators.AbstractMediator;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wso2.carbon.utils.xml.StringUtils;
 import org.wso2.openbanking.consumerdatastandards.au.policy.constants.CDSAccountValidationConstants;
 import org.wso2.openbanking.consumerdatastandards.au.policy.exceptions.CDSAccountValidationException;
 import org.wso2.openbanking.consumerdatastandards.au.policy.utils.CDSAccountValidationUtils;
@@ -56,8 +57,8 @@ public class CDSAccountValidationMediator extends AbstractMediator {
     }
 
     /**
-     * Enforces DOMS account validation for the account information header by removing linked-member
-     * authorization resources, filtering blocked accounts, and updating the signed header payload.
+     * Enforces CDS account validation for the account information header by removing linked-member,
+     * Secondary account owner authorization resources, filtering blocked accounts, and updating the signed payload.
      *
      * @param messageContext Synapse message context containing transport headers and mediation properties
      * @return {@code true} to continue the mediation flow
@@ -74,14 +75,14 @@ public class CDSAccountValidationMediator extends AbstractMediator {
             Map<String, String> headers = (Map<String, String>)
                     axis2Ctx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
 
-            String accountHeader = headers.get(CDSAccountValidationConstants.INFO_HEADER_TAG);
+            String accountHeaderJwt = headers.get(CDSAccountValidationConstants.INFO_HEADER_TAG);
 
             // Unsigned payload
-            JSONObject payload = new JSONObject(accountHeader);
-
-            //collect linkedMember authorization Ids
-            Set<String> linkedMemberAuthIds = new HashSet<>();
+            JSONObject payload = new JSONObject(accountHeaderJwt);
             String userId = null;
+
+            // Collect authorization IDs that should be removed from validation and mapping.
+            Set<String> excludedAuthIds = new HashSet<>();
 
             JSONArray authorizationResources = payload.optJSONArray(CDSAccountValidationConstants.AUTH_RESOURCES_TAG);
             if (authorizationResources != null) {
@@ -89,25 +90,19 @@ public class CDSAccountValidationMediator extends AbstractMediator {
 
                 for (int i = 0; i < authorizationResources.length(); i++) {
                     JSONObject authResource = authorizationResources.getJSONObject(i);
-
                     String authType = authResource.optString(CDSAccountValidationConstants.AUTH_TYPE_TAG);
+                    String authId = authResource.optString(CDSAccountValidationConstants.AUTH_ID_TAG);
 
-                    // Extract userId from the primary member auth resource
-                    if (CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG.equalsIgnoreCase(authType)) {
-                        userId = authResource.optString(CDSAccountValidationConstants.USER_ID_TAG, null);
-                    }
-
-                    // Removing Auth resources of linked members
-                    if (CDSAccountValidationConstants.LINKED_MEMBER_TAG.equalsIgnoreCase(authType)) {
-                        String linkedAuthId = authResource.optString(CDSAccountValidationConstants.AUTH_ID_TAG);
-                        if (linkedAuthId != null && !linkedAuthId.isEmpty()) {
-                            linkedMemberAuthIds.add(linkedAuthId);
-                        }
-                        if (log.isDebugEnabled()) {
-                            log.debug("Removing linkedMember authorization resource. authorizationId= "
-                                    + linkedAuthId);
+                    // Remove linked-member and secondary-owner auth resources.
+                    if (isExcludedAuthType(authType)) {
+                        if (!StringUtils.isEmpty(authId)) {
+                            excludedAuthIds.add(authId);
                         }
                         continue;
+                    }
+
+                    if (CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG.equalsIgnoreCase(authType)) {
+                        userId = authResource.optString(CDSAccountValidationConstants.USER_ID_TAG);
                     }
 
                     filteredAuthorizationResources.put(authResource);
@@ -126,10 +121,10 @@ public class CDSAccountValidationMediator extends AbstractMediator {
             Set<String> accountIds = new HashSet<>();
             for (int i = 0; i < consentMappingResources.length(); i++) {
                 JSONObject mappingResource = consentMappingResources.getJSONObject(i);
+                String authId = mappingResource.optString(CDSAccountValidationConstants.AUTH_ID_TAG);
 
-                // exclude linked-member accounts in DOMS call
-                if (linkedMemberAuthIds.contains(mappingResource.optString(
-                        CDSAccountValidationConstants.AUTH_ID_TAG))) {
+                // Exclude linked-member and secondary-user accounts in account validation call.(deduplicating accounts)
+                if (excludedAuthIds.contains(authId)) {
                     continue;
                 }
                 accountIds.add(mappingResource.optString(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG));
@@ -142,15 +137,16 @@ public class CDSAccountValidationMediator extends AbstractMediator {
 
             for (int i = 0; i < consentMappingResources.length(); i++) {
                 JSONObject mappingResource = consentMappingResources.getJSONObject(i);
+                String authId = mappingResource.optString(CDSAccountValidationConstants.AUTH_ID_TAG);
 
-                // Removing consentMappingResources of linked-members
-                if (linkedMemberAuthIds.contains(mappingResource.optString(
-                        CDSAccountValidationConstants.AUTH_ID_TAG))) {
+                // Removing consentMappingResources of joint account owners and secondary account owners
+                if (excludedAuthIds.contains(authId)) {
                     continue;
                 }
 
                 String accountId = mappingResource.optString(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG);
                 if (!blockedAccounts.contains(accountId)) {
+                    // Normalize the account id field from Accelerator format (account_id) to CDS format (accountId).
                     mappingResource.put(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, accountId);
                     mappingResource.remove(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG);
                     filteredConsentMappings.put(mappingResource);
@@ -193,4 +189,25 @@ public class CDSAccountValidationMediator extends AbstractMediator {
         messageContext.setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC, "500");
     }
 
+    /**
+     * Checks whether the given authorization type belongs to a secondary account owner.
+     *
+     * @param authType authorization type value
+     * @return {@code true} if the auth type is secondary individual or secondary joint account owner
+     */
+    private static boolean isSecondaryAccountOwnerAuthType(String authType) {
+        return CDSAccountValidationConstants.SECONDARY_INDIVIDUAL_ACCOUNT_OWNER_TAG.equalsIgnoreCase(authType)
+                || CDSAccountValidationConstants.SECONDARY_JOINT_ACCOUNT_OWNER_TAG.equalsIgnoreCase(authType);
+    }
+
+    /**
+     * Checks whether the given authorization type should be excluded from account validation and mappings.
+     *
+     * @param authType authorization type value
+     * @return {@code true} if auth type belongs to linked member or secondary account owner
+     */
+    private static boolean isExcludedAuthType(String authType) {
+        return CDSAccountValidationConstants.LINKED_MEMBER_TAG.equalsIgnoreCase(authType)
+                || isSecondaryAccountOwnerAuthType(authType);
+    }
 }

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
@@ -19,6 +19,7 @@
 package org.wso2.openbanking.consumerdatastandards.au.policy;
 
 import com.nimbusds.jose.JOSEException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
@@ -27,7 +28,6 @@ import org.apache.synapse.mediators.AbstractMediator;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.wso2.carbon.utils.xml.StringUtils;
 import org.wso2.openbanking.consumerdatastandards.au.policy.constants.CDSAccountValidationConstants;
 import org.wso2.openbanking.consumerdatastandards.au.policy.exceptions.CDSAccountValidationException;
 import org.wso2.openbanking.consumerdatastandards.au.policy.utils.CDSAccountValidationUtils;

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/constants/CDSAccountValidationConstants.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/constants/CDSAccountValidationConstants.java
@@ -51,6 +51,7 @@ public class CDSAccountValidationConstants {
     public static final String ERROR_DESCRIPTION = "ERROR_DESCRIPTION";
     public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
 
+
     // Constants related to DOMS
     public static final String ACCOUNT_IDS_TAG = "accountIds";
     public static final String LINKED_MEMBER_TAG = "linked_member";
@@ -59,6 +60,13 @@ public class CDSAccountValidationConstants {
 
     // Account-metadata webapp API paths
     public static final String DISCLOSURE_OPTIONS_PATH = "/disclosure-options";
+    public static final String SECONDARY_ACCOUNTS_PATH = "/secondary-accounts";
+
+    // Constants related to Secondary Accounts
+    public static final String SECONDARY_ACCOUNT_INSTRUCTION_STATUS_TAG = "secondaryAccountInstructionStatus";
+    public static final String SECONDARY_ACCOUNT_STATUS_INACTIVE = "inactive";
+    public static final String SECONDARY_INDIVIDUAL_ACCOUNT_OWNER_TAG = "secondary_individual_account_owner";
+    public static final String SECONDARY_JOINT_ACCOUNT_OWNER_TAG = "secondary_joint_account_owner";
 
     // Timeouts
     public static final int HTTP_CLIENT_CONNECT_TIMEOUT_MILLIS = 3000;

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
@@ -79,6 +79,7 @@ public class CDSAccountValidationUtils {
                 .build();
     }
 
+
     /**
      * Method to generate JWT with the given payload.
      *
@@ -115,9 +116,15 @@ public class CDSAccountValidationUtils {
             throws CDSAccountValidationException {
 
         String disclosureOptionsApi = baseUrl + CDSAccountValidationConstants.DISCLOSURE_OPTIONS_PATH;
+        String secondaryAccountsApi = baseUrl + CDSAccountValidationConstants.SECONDARY_ACCOUNTS_PATH;
 
         Set<String> blockedAccounts = fetchBlockedJointAccountsFromService(accountIds, disclosureOptionsApi,
                 basicAuthBase64);
+
+        Set<String> blockedSecondaryAccounts = fetchBlockedSecondaryAccountsFromService(accountIds,
+                secondaryAccountsApi, userId, basicAuthBase64);
+
+        blockedAccounts.addAll(blockedSecondaryAccounts);
 
         return blockedAccounts;
     }
@@ -198,6 +205,94 @@ public class CDSAccountValidationUtils {
             throw new CDSAccountValidationException(errorMessage, e);
         }
 
+        return blockedAccounts;
+    }
+
+    /**
+     * Call secondary accounts GET endpoint and return blocked account IDs.
+     * An account is considered blocked if its secondaryAccountInstructionStatus is "inactive".
+     *
+     * @param accountIds set of account IDs to check
+     * @param secondaryAccountsApi secondary accounts API endpoint
+     * @param userId user ID for the secondary accounts query
+     * @param basicAuthBase64 Base64-encoded Basic Auth credentials
+     * @return set of blocked account IDs
+     */
+    static Set<String> fetchBlockedSecondaryAccountsFromService(
+            Set<String> accountIds, String secondaryAccountsApi, String userId, String basicAuthBase64)
+            throws CDSAccountValidationException {
+
+        Set<String> blockedAccounts = new HashSet<>();
+
+        if (accountIds == null || accountIds.isEmpty()) {
+            return blockedAccounts;
+        }
+
+        if (StringUtils.isBlank(userId)) {
+            log.warn("[SecondaryAccounts] userId is blank, skipping secondary accounts check");
+            return blockedAccounts;
+        }
+
+        try {
+            String accountIdsParam = URLEncoder.encode(String.join(",", accountIds), StandardCharsets.UTF_8);
+            String userIdParam = URLEncoder.encode(userId, StandardCharsets.UTF_8);
+            String requestUrl = secondaryAccountsApi + "?" + CDSAccountValidationConstants.ACCOUNT_IDS_TAG + "="
+                    + accountIdsParam + "&" + CDSAccountValidationConstants.USER_ID_TAG + "=" + userIdParam;
+
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(requestUrl))
+                    .timeout(Duration.ofMillis(CDSAccountValidationConstants.HTTP_REQUEST_TIMEOUT_MILLIS))
+                    .header(CDSAccountValidationConstants.ACCEPT_TAG,
+                            CDSAccountValidationConstants.JSON_CONTENT_TYPE).GET();
+
+            requestBuilder.header(CDSAccountValidationConstants.AUTH_HEADER,
+                    CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
+
+            HttpRequest request = requestBuilder.build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                JSONArray secondaryAccounts;
+                try {
+                    secondaryAccounts = new JSONArray(response.body());
+                } catch (JSONException e) {
+                    String errorMessage = "Invalid secondary accounts service response";
+                    log.error(errorMessage, e);
+                    throw new CDSAccountValidationException(errorMessage, e);
+                }
+
+                for (int i = 0; i < secondaryAccounts.length(); i++) {
+                    JSONObject accountInstruction = secondaryAccounts.optJSONObject(i);
+                    if (accountInstruction == null) {
+                        continue;
+                    }
+                    String instructionStatus = accountInstruction.optString(
+                            CDSAccountValidationConstants.SECONDARY_ACCOUNT_INSTRUCTION_STATUS_TAG, null);
+
+                    if (CDSAccountValidationConstants.SECONDARY_ACCOUNT_STATUS_INACTIVE
+                            .equalsIgnoreCase(instructionStatus)) {
+                        String accountId = accountInstruction.optString(
+                                CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
+                        if (StringUtils.isNotBlank(accountId)) {
+                            blockedAccounts.add(accountId);
+                        }
+                    }
+                }
+            } else {
+                String errorMessage = "Secondary accounts service returned HTTP " + response.statusCode();
+                log.error(errorMessage);
+                throw new CDSAccountValidationException(errorMessage);
+            }
+
+        } catch (IOException e) {
+            String errorMessage = "[SecondaryAccounts] Error calling secondary accounts service";
+            log.error(errorMessage, e);
+            throw new CDSAccountValidationException(errorMessage, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            String errorMessage = "[SecondaryAccounts] Interrupted while calling secondary accounts service";
+            log.error(errorMessage, e);
+            throw new CDSAccountValidationException(errorMessage, e);
+        }
         return blockedAccounts;
     }
 }

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
@@ -79,7 +79,6 @@ public class CDSAccountValidationUtils {
                 .build();
     }
 
-
     /**
      * Method to generate JWT with the given payload.
      *

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
@@ -62,6 +62,9 @@ public class CDSAccountValidationMediatorTest {
         Mockito.when(axis2MessageContext.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(headers);
     }
 
+    /**
+     * Verifies mediation falls back to policy error handling when account filtering/signing flow fails.
+     */
     @Test
     public void testMediateFiltersBlockedAccountsAndUpdatesHeader() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -112,6 +115,9 @@ public class CDSAccountValidationMediatorTest {
                 "Error during CDS mediation policy");
     }
 
+    /**
+     * Verifies invalid info-header payloads are handled by setting policy error properties.
+     */
     @Test
     public void testMediateHandlesDecodeError() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -131,6 +137,9 @@ public class CDSAccountValidationMediatorTest {
                 "Error during CDS mediation policy");
     }
 
+    /**
+     * Verifies linked and blocked accounts are filtered out and the updated payload is re-signed.
+     */
     @Test
     public void testMediateFiltersLinkedAndBlockedAccountsAndSignsHeader() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -181,6 +190,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies JWT signing failures are converted into mediation error properties.
+     */
     @Test
     public void testMediateSetsErrorPropertiesWhenJwtGenerationFails() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -216,6 +228,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies mediation succeeds without errors when consent mapping resources are absent.
+     */
     @Test
     public void testMediateWithNoConsentMappingResources() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -232,6 +247,9 @@ public class CDSAccountValidationMediatorTest {
                 .setProperty(Mockito.eq(CDSAccountValidationConstants.ERROR_CODE), Mockito.any());
     }
 
+    /**
+     * Verifies mediation proceeds with a null user context when authorization resources are absent.
+     */
     @Test
     public void testMediateWithNoAuthorizationResources() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -264,6 +282,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies accounts mapped to secondary-owner authorization types are excluded from validation.
+     */
     @Test
     public void testMediateExcludesSecondaryAccountOwnerAuthTypes() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -320,6 +341,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies account_id fields are normalized to accountId when no accounts are blocked.
+     */
     @Test
     public void testMediateWithNoBlockedAccountsNormalizesAccountIdField() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -371,6 +395,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies account-validation service failures are translated into mediation error properties.
+     */
     @Test
     public void testMediateSetsErrorPropertiesWhenAccountValidationFails() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
@@ -23,6 +23,7 @@ import org.apache.axis2.context.MessageContext;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -35,8 +36,10 @@ import org.wso2.openbanking.consumerdatastandards.au.policy.utils.CDSAccountVali
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Unit tests for {@link CDSAccountValidationMediator}.
@@ -119,13 +122,13 @@ public class CDSAccountValidationMediatorTest {
 
         Assert.assertTrue(result);
         Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
-            "Internal Server Error");
+                "Internal Server Error");
         Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
-            "CDS DOMS Policy Error");
+                "CDS DOMS Policy Error");
         Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC,
-            "500");
+                "500");
         Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_DESCRIPTION,
-            "Error during CDS mediation policy");
+                "Error during CDS mediation policy");
     }
 
     @Test
@@ -138,42 +141,42 @@ public class CDSAccountValidationMediatorTest {
 
         JSONArray authorizationResources = new JSONArray();
         authorizationResources.put(new JSONObject()
-            .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.LINKED_MEMBER_TAG)
-            .put(CDSAccountValidationConstants.AUTH_ID_TAG, "linked-1"));
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.LINKED_MEMBER_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "linked-1"));
         authorizationResources.put(new JSONObject()
-            .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
-            .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")
-            .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
         payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
 
         JSONArray accounts = new JSONArray();
         accounts.put(new JSONObject()
-            .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-linked")
-            .put(CDSAccountValidationConstants.AUTH_ID_TAG, "linked-1"));
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-linked")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "linked-1"));
         accounts.put(new JSONObject()
-            .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
-            .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2"));
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2"));
         accounts.put(new JSONObject()
-            .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-2")
-            .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2"));
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-2")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2"));
         payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
         headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
-                Mockito.eq("dGVzdDp0ZXN0")))
-                .thenReturn(java.util.Collections.singleton("acc-2"));
+                            Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
+                            Mockito.eq("dGVzdDp0ZXN0")))
+                    .thenReturn(java.util.Collections.singleton("acc-2"));
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
-                .thenReturn("signed-jwt");
+                    .thenReturn("signed-jwt");
 
             boolean result = mediator.mediate(synapseMessageContext);
 
             Assert.assertTrue(result);
             Assert.assertEquals(headers.get(CDSAccountValidationConstants.INFO_HEADER_TAG), "signed-jwt");
             utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
-                Mockito.eq("dGVzdDp0ZXN0")));
+                    Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
+                    Mockito.eq("dGVzdDp0ZXN0")));
             utilsMock.verify(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()));
         }
     }
@@ -187,17 +190,17 @@ public class CDSAccountValidationMediatorTest {
         JSONObject payload = new JSONObject();
         payload.put(CDSAccountValidationConstants.USER_ID_TAG, "user-2");
         payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG,
-            new JSONArray().put(new JSONObject()
-                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
-                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")));
+                new JSONArray().put(new JSONObject()
+                        .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                        .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")));
         headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(java.util.Collections.emptySet());
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(java.util.Collections.emptySet());
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
-                .thenThrow(new JOSEException("signing failed"));
+                    .thenThrow(new JOSEException("signing failed"));
 
             boolean result = mediator.mediate(synapseMessageContext);
 
@@ -205,11 +208,166 @@ public class CDSAccountValidationMediatorTest {
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
                     "Internal Server Error");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
-                "CDS DOMS Policy Error");
+                    "CDS DOMS Policy Error");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC,
-                "500");
+                    "500");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_DESCRIPTION,
-                "Error during CDS mediation policy");
+                    "Error during CDS mediation policy");
+        }
+    }
+
+    @Test
+    public void testMediateWithNoConsentMappingResources() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+
+        JSONObject payload = new JSONObject();
+        // No consentMappingResources — mediator should log a warning and return true without error
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        boolean result = mediator.mediate(synapseMessageContext);
+
+        Assert.assertTrue(result);
+        Mockito.verify(synapseMessageContext, Mockito.never())
+                .setProperty(Mockito.eq(CDSAccountValidationConstants.ERROR_CODE), Mockito.any());
+    }
+
+    @Test
+    public void testMediateWithNoAuthorizationResources() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        // No authorizationResources — userId stays null, no accounts excluded
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.isNull(), Mockito.anyString()))
+                    .thenReturn(Collections.emptySet());
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            // userId should be null because there were no authorizationResources
+            utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                    Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL),
+                    Mockito.isNull(), Mockito.eq("dGVzdDp0ZXN0")));
+        }
+    }
+
+    @Test
+    public void testMediateExcludesSecondaryAccountOwnerAuthTypes() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        JSONArray authorizationResources = new JSONArray();
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG,
+                        CDSAccountValidationConstants.SECONDARY_INDIVIDUAL_ACCOUNT_OWNER_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "sec-ind-auth"));
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG,
+                        CDSAccountValidationConstants.SECONDARY_JOINT_ACCOUNT_OWNER_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "sec-joint-auth"));
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+        payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
+
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-sec-ind")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "sec-ind-auth"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-sec-joint")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "sec-joint-auth"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-primary")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Collections.emptySet());
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            // Only the primary account should be passed to fetchAllBlockedAccounts;
+            // secondary account owner accounts are excluded from validation.
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Set<String>> accountIdsCaptor = ArgumentCaptor.forClass(Set.class);
+            utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                    accountIdsCaptor.capture(), Mockito.any(), Mockito.any(), Mockito.any()));
+            Assert.assertEquals(accountIdsCaptor.getValue().size(), 1);
+            Assert.assertTrue(accountIdsCaptor.getValue().contains("acc-primary"));
+        }
+    }
+
+    @Test
+    public void testMediateWithNoBlockedAccountsNormalizesAccountIdField() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        JSONArray authorizationResources = new JSONArray();
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+        payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
+
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-2")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Collections.emptySet());
+
+            ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(jwtPayloadCaptor.capture()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            Assert.assertEquals(headers.get(CDSAccountValidationConstants.INFO_HEADER_TAG), "signed-jwt");
+
+            // Verify all accounts passed through and account_id was renamed to accountId
+            JSONObject capturedJson = new JSONObject(jwtPayloadCaptor.getValue());
+            JSONArray filteredMappings = capturedJson
+                    .getJSONArray(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG);
+            Assert.assertEquals(filteredMappings.length(), 2);
+            for (int i = 0; i < filteredMappings.length(); i++) {
+                JSONObject mapping = filteredMappings.getJSONObject(i);
+                Assert.assertTrue(mapping.has(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG));
+                Assert.assertFalse(mapping.has(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG));
+            }
         }
     }
 
@@ -225,15 +383,15 @@ public class CDSAccountValidationMediatorTest {
                 .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")
                 .put(CDSAccountValidationConstants.USER_ID_TAG, "user-2")));
         payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG,
-            new JSONArray().put(new JSONObject()
-                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
-                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")));
+                new JSONArray().put(new JSONObject()
+                        .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                        .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-2")));
         headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                .thenThrow(new CDSAccountValidationException("metadata service unavailable"));
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenThrow(new CDSAccountValidationException("metadata service unavailable"));
 
             boolean result = mediator.mediate(synapseMessageContext);
 
@@ -241,11 +399,11 @@ public class CDSAccountValidationMediatorTest {
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
                     "Internal Server Error");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
-                "CDS DOMS Policy Error");
+                    "CDS DOMS Policy Error");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC,
-                "500");
+                    "500");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_DESCRIPTION,
-                "Error during CDS mediation policy");
+                    "Error during CDS mediation policy");
         }
     }
 }

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
@@ -48,6 +48,9 @@ public class CDSAccountValidationUtilsTest {
 
     private static final String BASIC_AUTH = Base64.getEncoder().encodeToString("user:pass".getBytes());
 
+    /**
+    * Verifies blocked joint accounts are extracted when the metadata service returns a valid response.
+    */
     @Test
     public void testFetchBlockedAccountsFromServiceSuccess() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -83,6 +86,9 @@ public class CDSAccountValidationUtilsTest {
                 "Basic " + BASIC_AUTH);
     }
 
+    /**
+    * Verifies a non-200 DOMS response is surfaced as a validation exception.
+    */
     @Test
     public void testFetchBlockedAccountsFromServiceNon200() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -102,6 +108,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, DOMS_ENDPOINT, BASIC_AUTH));
     }
 
+    /**
+    * Verifies I/O failures from the DOMS service call are wrapped as validation exceptions.
+    */
     @Test
     public void testFetchBlockedAccountsFromServiceIoError() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -118,6 +127,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, DOMS_ENDPOINT, BASIC_AUTH));
     }
 
+    /**
+    * Verifies Basic authorization is sent when fetching blocked joint accounts.
+    */
     @Test
     public void testFetchBlockedAccountsWithAuthHeader() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -150,6 +162,9 @@ public class CDSAccountValidationUtilsTest {
                 "Basic " + BASIC_AUTH);
     }
 
+    /**
+    * Verifies successful DOMS calls include the required authorization header.
+    */
     @Test
     public void testFetchBlockedAccountsSuccessIncludesRequiredAuthHeader() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -182,6 +197,9 @@ public class CDSAccountValidationUtilsTest {
                 "Basic " + BASIC_AUTH);
     }
 
+    /**
+    * Verifies empty or null account sets return an empty blocked-account result.
+    */
     @Test
     public void testFetchBlockedAccountsFromServiceWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedJointAccountsFromService(
@@ -195,6 +213,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
+    /**
+     * Verifies malformed DOMS rows are ignored while valid no-sharing entries are still processed.
+     */
     @Test
     public void testFetchBlockedAccountsSkipsInvalidRowsAndBlankAccountId() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -221,6 +242,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.contains("acc-5"));
     }
 
+    /**
+     * Verifies interrupted DOMS requests raise a validation exception and preserve interrupt status.
+     */
     @Test
     public void testFetchBlockedAccountsFromServiceInterruptedError() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -240,6 +264,9 @@ public class CDSAccountValidationUtilsTest {
         Thread.interrupted();
     }
 
+    /**
+     * Verifies malformed DOMS payloads trigger a validation exception.
+     */
     @Test
     public void testFetchBlockedAccountsFromServiceMalformedResponse() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -262,6 +289,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchBlockedSecondaryAccountsFromService tests ----
 
+    /**
+     * Verifies inactive secondary-account instructions are marked as blocked.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsSuccess() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -289,6 +319,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertFalse(blocked.contains("acc-2"));
     }
 
+    /**
+     * Verifies non-200 responses from the secondary-account endpoint raise a validation exception.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsNon200() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -309,6 +342,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies I/O failures from the secondary-account endpoint are wrapped as validation exceptions.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsIoError() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -326,6 +362,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies interrupted secondary-account requests raise a validation exception and preserve interrupt status.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsInterruptedError() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -345,6 +384,9 @@ public class CDSAccountValidationUtilsTest {
         Thread.interrupted();
     }
 
+    /**
+     * Verifies malformed secondary-account payloads trigger a validation exception.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsMalformedResponse() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -365,6 +407,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies empty or null account sets return an empty secondary blocked-account result.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
@@ -378,6 +423,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
+    /**
+     * Verifies blank or null primary user IDs short-circuit with an empty blocked-account result.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsWithBlankUserId() throws CDSAccountValidationException {
         Set<String> accounts = new HashSet<>();
@@ -394,6 +442,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
+    /**
+     * Verifies both accountIds and userId query parameters are included for secondary-account requests.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsIncludesUserIdInRequest() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -421,6 +472,9 @@ public class CDSAccountValidationUtilsTest {
                 "Basic " + BASIC_AUTH);
     }
 
+    /**
+     * Verifies invalid rows and active instructions are skipped while inactive rows are blocked.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsSkipsInvalidAndNonInactiveRows() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -452,6 +506,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchAllBlockedAccounts tests ----
 
+    /**
+     * Verifies blocked-account results from DOMS and secondary-account checks are merged.
+     */
     @Test
     public void testFetchAllBlockedAccountsCombinesResults() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
@@ -488,6 +545,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- generateJWT tests ----
 
+    /**
+     * Verifies JWT generation returns a signed compact token when key material is available.
+     */
     @Test
     public void testGenerateJwtSuccess() throws Exception {
         try {

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
@@ -43,6 +43,8 @@ public class CDSAccountValidationUtilsTest {
 
     private static final String ACCOUNT_METADATA_WEBAPP_BASE_URL = "http://account-metadata-webapp-base-url";
     private static final String DOMS_ENDPOINT = ACCOUNT_METADATA_WEBAPP_BASE_URL + "/disclosure-options";
+    private static final String SECONDARY_ACCOUNTS_ENDPOINT =
+            ACCOUNT_METADATA_WEBAPP_BASE_URL + "/secondary-accounts";
 
     private static final String BASIC_AUTH = Base64.getEncoder().encodeToString("user:pass".getBytes());
 
@@ -257,6 +259,234 @@ public class CDSAccountValidationUtilsTest {
                 () -> CDSAccountValidationUtils.fetchBlockedJointAccountsFromService(
                         accounts, DOMS_ENDPOINT, BASIC_AUTH));
     }
+
+    // ---- fetchBlockedSecondaryAccountsFromService tests ----
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsSuccess() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
+
+        Mockito.when(response.statusCode()).thenReturn(200);
+        Mockito.when(response.body()).thenReturn("["
+                + "{\"accountId\":\"acc-1\",\"secondaryAccountInstructionStatus\":\"inactive\"},"
+                + "{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"active\"}"
+                + "]");
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        accounts.add("acc-2");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH);
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-1"));
+        Assert.assertFalse(blocked.contains("acc-2"));
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsNon200() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
+
+        Mockito.when(response.statusCode()).thenReturn(503);
+        Mockito.when(response.body()).thenReturn("[]");
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                        accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsIoError() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenThrow(new java.io.IOException("Connection refused"));
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                        accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsInterruptedError() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                        accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
+        Assert.assertTrue(Thread.currentThread().isInterrupted());
+        Thread.interrupted();
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsMalformedResponse() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
+
+        Mockito.when(response.statusCode()).thenReturn(200);
+        Mockito.when(response.body()).thenReturn("{not-an-array");
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                        accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
+        Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                Collections.emptySet(), SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH);
+        Set<String> blockedForNull = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                null, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH);
+
+        Assert.assertNotNull(blockedForEmpty);
+        Assert.assertNotNull(blockedForNull);
+        Assert.assertTrue(blockedForEmpty.isEmpty());
+        Assert.assertTrue(blockedForNull.isEmpty());
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsWithBlankUserId() throws CDSAccountValidationException {
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                accounts, SECONDARY_ACCOUNTS_ENDPOINT, "", BASIC_AUTH);
+        Set<String> blockedForNull = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                accounts, SECONDARY_ACCOUNTS_ENDPOINT, null, BASIC_AUTH);
+
+        Assert.assertNotNull(blockedForBlank);
+        Assert.assertNotNull(blockedForNull);
+        Assert.assertTrue(blockedForBlank.isEmpty());
+        Assert.assertTrue(blockedForNull.isEmpty());
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsIncludesUserIdInRequest() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
+
+        Mockito.when(response.statusCode()).thenReturn(200);
+        Mockito.when(response.body()).thenReturn("[]");
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-99", BASIC_AUTH);
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        Mockito.verify(client).send(requestCaptor.capture(), Mockito.<HttpResponse.BodyHandler<String>>any());
+        String requestUri = requestCaptor.getValue().uri().toString();
+        Assert.assertTrue(requestUri.contains("accountIds="));
+        Assert.assertTrue(requestUri.contains("userId="));
+        Assert.assertEquals(requestCaptor.getValue().headers().firstValue("Authorization").orElse(null),
+                "Basic " + BASIC_AUTH);
+    }
+
+    @Test
+    public void testFetchBlockedSecondaryAccountsSkipsInvalidAndNonInactiveRows() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
+
+        Mockito.when(response.statusCode()).thenReturn(200);
+        Mockito.when(response.body()).thenReturn("["
+                + "\"invalid-string-entry\","
+                + "{\"secondaryAccountInstructionStatus\":\"inactive\"},"
+                + "{\"accountId\":\"acc-active\",\"secondaryAccountInstructionStatus\":\"active\"},"
+                + "{\"accountId\":\"acc-inactive\",\"secondaryAccountInstructionStatus\":\"inactive\"}"
+                + "]");
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(response);
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-active");
+        accounts.add("acc-inactive");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH);
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-inactive"));
+        Assert.assertFalse(blocked.contains("acc-active"));
+    }
+
+    // ---- fetchAllBlockedAccounts tests ----
+
+    @Test
+    public void testFetchAllBlockedAccountsCombinesResults() throws Exception {
+        HttpClient client = Mockito.mock(HttpClient.class);
+        HttpResponse<String> disclosureResponse = Mockito.mock(HttpResponse.class);
+        HttpResponse<String> secondaryResponse = Mockito.mock(HttpResponse.class);
+
+        Mockito.when(disclosureResponse.statusCode()).thenReturn(200);
+        Mockito.when(disclosureResponse.body()).thenReturn("["
+                + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"}"
+                + "]");
+        Mockito.when(secondaryResponse.statusCode()).thenReturn(200);
+        Mockito.when(secondaryResponse.body()).thenReturn("["
+                + "{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"inactive\"}"
+                + "]");
+        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(disclosureResponse)
+                .thenReturn(secondaryResponse);
+
+        CDSAccountValidationUtils.setHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        accounts.add("acc-2");
+        accounts.add("acc-3");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                accounts, ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH);
+
+        Assert.assertEquals(blocked.size(), 2);
+        Assert.assertTrue(blocked.contains("acc-1"));
+        Assert.assertTrue(blocked.contains("acc-2"));
+        Assert.assertFalse(blocked.contains("acc-3"));
+    }
+
+    // ---- generateJWT tests ----
 
     @Test
     public void testGenerateJwtSuccess() throws Exception {


### PR DESCRIPTION
Add CDS Policy to Filter SUI-Blocked Accounts from Account Resource API

This pull request introduces a CDS policy enhancement to support the Secondary User Instruction (SUI) feature in CDS Toolkit 2.0.

The implementation ensures that only accounts with valid and active secondary user instructions are considered during account resource API responses. This aligns with CDS compliance requirements by enforcing instruction status and preventing unauthorized access to account data by non-nominated users.

The update improves consent enforcement and strengthens data governance by ensuring only properly authorized representatives can access account information during retrieval operations.

------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [x] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).