### PR TITLE
Add CDS Policy to Filter BNR-Blocked Accounts from Account Resource API

### DIFF
--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
@@ -101,6 +101,7 @@ public class CDSAccountValidationMediator extends AbstractMediator {
                         continue;
                     }
 
+                    // Extracting the primary userID
                     if (CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG.equalsIgnoreCase(authType)) {
                         userId = authResource.optString(CDSAccountValidationConstants.USER_ID_TAG);
                     }
@@ -123,7 +124,7 @@ public class CDSAccountValidationMediator extends AbstractMediator {
                 JSONObject mappingResource = consentMappingResources.getJSONObject(i);
                 String authId = mappingResource.optString(CDSAccountValidationConstants.AUTH_ID_TAG);
 
-                // Exclude linked-member and secondary-user accounts in account validation call.(deduplicating accounts)
+                // Removing duplicates of linked-member,secondary-user,business accounts in account validation calls.
                 if (excludedAuthIds.contains(authId)) {
                     continue;
                 }
@@ -139,14 +140,14 @@ public class CDSAccountValidationMediator extends AbstractMediator {
                 JSONObject mappingResource = consentMappingResources.getJSONObject(i);
                 String authId = mappingResource.optString(CDSAccountValidationConstants.AUTH_ID_TAG);
 
-                // Removing consentMappingResources of joint account owners and secondary account owners
+                // Removing consentMappingResources of other users.
                 if (excludedAuthIds.contains(authId)) {
                     continue;
                 }
 
                 String accountId = mappingResource.optString(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG);
                 if (!blockedAccounts.contains(accountId)) {
-                    // Normalize the account id field from Accelerator format (account_id) to CDS format (accountId).
+                    // Changing the Account id field from Accelerator format (account_id) to CDS format (accountId).
                     mappingResource.put(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, accountId);
                     mappingResource.remove(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG);
                     filteredConsentMappings.put(mappingResource);
@@ -201,6 +202,17 @@ public class CDSAccountValidationMediator extends AbstractMediator {
     }
 
     /**
+     * Checks whether the given authorization type belongs to a business account stakeholder.
+     *
+     * @param authType authorization type value
+     * @return {@code true} if the auth type is nominated representative or business account owner
+     */
+    private static boolean isBusinessAccountAuthType(String authType) {
+        return CDSAccountValidationConstants.NOMINATED_REPRESENTATIVE_TAG.equalsIgnoreCase(authType)
+                || CDSAccountValidationConstants.BUSINESS_ACCOUNT_OWNER_TAG.equalsIgnoreCase(authType);
+    }
+
+    /**
      * Checks whether the given authorization type should be excluded from account validation and mappings.
      *
      * @param authType authorization type value
@@ -208,6 +220,6 @@ public class CDSAccountValidationMediator extends AbstractMediator {
      */
     private static boolean isExcludedAuthType(String authType) {
         return CDSAccountValidationConstants.LINKED_MEMBER_TAG.equalsIgnoreCase(authType)
-                || isSecondaryAccountOwnerAuthType(authType);
+                || isSecondaryAccountOwnerAuthType(authType) || isBusinessAccountAuthType(authType);
     }
 }

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/constants/CDSAccountValidationConstants.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/constants/CDSAccountValidationConstants.java
@@ -61,12 +61,19 @@ public class CDSAccountValidationConstants {
     // Account-metadata webapp API paths
     public static final String DISCLOSURE_OPTIONS_PATH = "/disclosure-options";
     public static final String SECONDARY_ACCOUNTS_PATH = "/secondary-accounts";
+    public static final String BUSINESS_STAKEHOLDERS_PATH = "/business-stakeholders";
 
     // Constants related to Secondary Accounts
     public static final String SECONDARY_ACCOUNT_INSTRUCTION_STATUS_TAG = "secondaryAccountInstructionStatus";
     public static final String SECONDARY_ACCOUNT_STATUS_INACTIVE = "inactive";
     public static final String SECONDARY_INDIVIDUAL_ACCOUNT_OWNER_TAG = "secondary_individual_account_owner";
     public static final String SECONDARY_JOINT_ACCOUNT_OWNER_TAG = "secondary_joint_account_owner";
+
+    // Constants related to Business Accounts
+    public static final String NOMINATED_REPRESENTATIVE_TAG = "nominated_representative";
+    public static final String BUSINESS_ACCOUNT_OWNER_TAG = "business_account_owner";
+    public static final String BUSINESS_PERMISSION_TAG = "permission";
+    public static final String BUSINESS_PERMISSION_AUTHORIZE = "AUTHORIZE";
 
     // Timeouts
     public static final int HTTP_CLIENT_CONNECT_TIMEOUT_MILLIS = 3000;

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
@@ -79,6 +79,7 @@ public class CDSAccountValidationUtils {
                 .build();
     }
 
+
     /**
      * Method to generate JWT with the given payload.
      *
@@ -114,16 +115,24 @@ public class CDSAccountValidationUtils {
             Set<String> accountIds, String baseUrl, String userId, String basicAuthBase64)
             throws CDSAccountValidationException {
 
+        if (StringUtils.isBlank(userId)) {
+            log.warn("[CDS-policy] no primary userId, skipping cds account validation.");
+            return new HashSet<>();
+        }
+
         String disclosureOptionsApi = baseUrl + CDSAccountValidationConstants.DISCLOSURE_OPTIONS_PATH;
         String secondaryAccountsApi = baseUrl + CDSAccountValidationConstants.SECONDARY_ACCOUNTS_PATH;
+        String businessStakeholdersApi = baseUrl + CDSAccountValidationConstants.BUSINESS_STAKEHOLDERS_PATH;
 
         Set<String> blockedAccounts = fetchBlockedJointAccountsFromService(accountIds, disclosureOptionsApi,
                 basicAuthBase64);
-
         Set<String> blockedSecondaryAccounts = fetchBlockedSecondaryAccountsFromService(accountIds,
                 secondaryAccountsApi, userId, basicAuthBase64);
+        Set<String> blockedBusinessAccounts = fetchBlockedBusinessAccountsFromService(accountIds,
+                businessStakeholdersApi, userId, basicAuthBase64);
 
         blockedAccounts.addAll(blockedSecondaryAccounts);
+        blockedAccounts.addAll(blockedBusinessAccounts);
 
         return blockedAccounts;
     }
@@ -227,11 +236,6 @@ public class CDSAccountValidationUtils {
             return blockedAccounts;
         }
 
-        if (StringUtils.isBlank(userId)) {
-            log.warn("[SecondaryAccounts] userId is blank, skipping secondary accounts check");
-            return blockedAccounts;
-        }
-
         try {
             String accountIdsParam = URLEncoder.encode(String.join(",", accountIds), StandardCharsets.UTF_8);
             String userIdParam = URLEncoder.encode(userId, StandardCharsets.UTF_8);
@@ -289,6 +293,94 @@ public class CDSAccountValidationUtils {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             String errorMessage = "[SecondaryAccounts] Interrupted while calling secondary accounts service";
+            log.error(errorMessage, e);
+            throw new CDSAccountValidationException(errorMessage, e);
+        }
+        return blockedAccounts;
+    }
+
+    /**
+     * Call business stakeholders GET endpoint and return blocked account IDs.
+     * An account is considered blocked when business permission is not AUTHORIZE.
+     *
+     * @param accountIds set of account IDs to check
+     * @param businessStakeholdersApi business stakeholders API endpoint
+     * @param userId user ID for the business stakeholders query
+     * @param basicAuthBase64 Base64-encoded Basic Auth credentials
+     * @return set of blocked account IDs
+     */
+    static Set<String> fetchBlockedBusinessAccountsFromService(Set<String> accountIds, String businessStakeholdersApi,
+                                                               String userId, String basicAuthBase64)
+            throws CDSAccountValidationException {
+
+        Set<String> blockedAccounts = new HashSet<>();
+
+        if (accountIds == null || accountIds.isEmpty()) {
+            return blockedAccounts;
+        }
+
+        try {
+            String accountIdsParam = URLEncoder.encode(String.join(",", accountIds), StandardCharsets.UTF_8);
+            String userIdParam = URLEncoder.encode(userId, StandardCharsets.UTF_8);
+            String requestUrl = businessStakeholdersApi + "?" + CDSAccountValidationConstants.ACCOUNT_IDS_TAG + "="
+                    + accountIdsParam + "&" + CDSAccountValidationConstants.USER_ID_TAG + "=" + userIdParam;
+
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(requestUrl))
+                    .timeout(Duration.ofMillis(CDSAccountValidationConstants.HTTP_REQUEST_TIMEOUT_MILLIS))
+                    .header(CDSAccountValidationConstants.ACCEPT_TAG,
+                            CDSAccountValidationConstants.JSON_CONTENT_TYPE).GET();
+
+            if (StringUtils.isNotBlank(basicAuthBase64)) {
+                requestBuilder.header(CDSAccountValidationConstants.AUTH_HEADER,
+                        CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
+            } else {
+                String errorMessage = "[BusinessStakeholders] Basic Auth property not set, request may fail";
+                log.error(errorMessage);
+                throw new CDSAccountValidationException(errorMessage);
+            }
+
+            HttpRequest request = requestBuilder.build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                JSONArray businessStakeholders;
+                try {
+                    businessStakeholders = new JSONArray(response.body());
+                } catch (JSONException e) {
+                    String errorMessage = "Invalid business stakeholders service response";
+                    log.error(errorMessage, e);
+                    throw new CDSAccountValidationException(errorMessage, e);
+                }
+
+                for (int i = 0; i < businessStakeholders.length(); i++) {
+                    JSONObject permissionItem = businessStakeholders.optJSONObject(i);
+                    if (permissionItem == null) {
+                        continue;
+                    }
+
+                    String permission = permissionItem.optString(
+                            CDSAccountValidationConstants.BUSINESS_PERMISSION_TAG, null);
+                    if (!CDSAccountValidationConstants.BUSINESS_PERMISSION_AUTHORIZE.equalsIgnoreCase(permission)) {
+                        String accountId = permissionItem.optString(
+                                CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
+                        if (StringUtils.isNotBlank(accountId)) {
+                            blockedAccounts.add(accountId);
+                        }
+                    }
+                }
+            } else {
+                String errorMessage = "Business stakeholders service returned HTTP " + response.statusCode();
+                log.error(errorMessage);
+                throw new CDSAccountValidationException(errorMessage);
+            }
+
+        } catch (IOException e) {
+            String errorMessage = "[BusinessStakeholders] Error calling business stakeholders service";
+            log.error(errorMessage, e);
+            throw new CDSAccountValidationException(errorMessage, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            String errorMessage = "[BusinessStakeholders] Interrupted while calling business stakeholders service";
             log.error(errorMessage, e);
             throw new CDSAccountValidationException(errorMessage, e);
         }

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
@@ -175,7 +175,7 @@ public class CDSAccountValidationMediatorTest {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
                             Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
                             Mockito.eq("dGVzdDp0ZXN0")))
-                    .thenReturn(java.util.Collections.singleton("acc-2"));
+                    .thenReturn(Collections.singleton("acc-2"));
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
                     .thenReturn("signed-jwt");
 
@@ -210,7 +210,7 @@ public class CDSAccountValidationMediatorTest {
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
                             Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-                    .thenReturn(java.util.Collections.emptySet());
+                    .thenReturn(Collections.emptySet());
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
                     .thenThrow(new JOSEException("signing failed"));
 
@@ -398,6 +398,174 @@ public class CDSAccountValidationMediatorTest {
     /**
      * Verifies account-validation service failures are translated into mediation error properties.
      */
+    @Test
+    public void testMediateExcludesBusinessAccountOwnerAuthTypes() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        JSONArray authorizationResources = new JSONArray();
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG,
+                        CDSAccountValidationConstants.NOMINATED_REPRESENTATIVE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "nom-rep-auth"));
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG,
+                        CDSAccountValidationConstants.BUSINESS_ACCOUNT_OWNER_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "biz-owner-auth"));
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+        payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
+
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-nom-rep")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "nom-rep-auth"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-biz-owner")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "biz-owner-auth"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-primary")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Collections.emptySet());
+
+            ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(jwtPayloadCaptor.capture()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            // Only the primary account is passed to fetchAllBlockedAccounts
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Set<String>> accountIdsCaptor = ArgumentCaptor.forClass(Set.class);
+            utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                    accountIdsCaptor.capture(), Mockito.any(), Mockito.any(), Mockito.any()));
+            Assert.assertEquals(accountIdsCaptor.getValue().size(), 1);
+            Assert.assertTrue(accountIdsCaptor.getValue().contains("acc-primary"));
+
+            // Business accounts must also be excluded from consentMappingResources in the signed JWT
+            JSONObject capturedJson = new JSONObject(jwtPayloadCaptor.getValue());
+            JSONArray filteredMappings = capturedJson
+                    .getJSONArray(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG);
+            Assert.assertEquals(filteredMappings.length(), 1);
+            Assert.assertEquals(filteredMappings.getJSONObject(0)
+                    .getString(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG), "acc-primary");
+        }
+    }
+
+    @Test
+    public void testMediateAllAccountsBlocked() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        JSONArray authorizationResources = new JSONArray();
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+        payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
+
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-2")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Set.of("acc-1", "acc-2"));
+
+            ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(jwtPayloadCaptor.capture()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            JSONObject capturedJson = new JSONObject(jwtPayloadCaptor.getValue());
+            JSONArray filteredMappings = capturedJson
+                    .getJSONArray(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG);
+            Assert.assertEquals(filteredMappings.length(), 0);
+        }
+    }
+
+    @Test
+    public void testMediateVerifiesFilteredAuthResourcesAndMappingsInSignedPayload() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        JSONArray authorizationResources = new JSONArray();
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.LINKED_MEMBER_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "linked-auth"));
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+        payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
+
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-linked")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "linked-auth"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-blocked")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth"));
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-allowed")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "primary-auth"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Collections.singleton("acc-blocked"));
+
+            ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(jwtPayloadCaptor.capture()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            JSONObject capturedJson = new JSONObject(jwtPayloadCaptor.getValue());
+
+            // linked_member must be removed from authorizationResources in the signed payload
+            JSONArray filteredAuth = capturedJson.getJSONArray(CDSAccountValidationConstants.AUTH_RESOURCES_TAG);
+            Assert.assertEquals(filteredAuth.length(), 1);
+            Assert.assertEquals(filteredAuth.getJSONObject(0)
+                    .getString(CDSAccountValidationConstants.AUTH_TYPE_TAG),
+                    CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG);
+
+            // acc-linked (excluded) and acc-blocked (blocked) must be absent; only acc-allowed survives
+            JSONArray filteredMappings = capturedJson
+                    .getJSONArray(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG);
+            Assert.assertEquals(filteredMappings.length(), 1);
+            Assert.assertEquals(filteredMappings.getJSONObject(0)
+                    .getString(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG), "acc-allowed");
+        }
+    }
+
     @Test
     public void testMediateSetsErrorPropertiesWhenAccountValidationFails() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
@@ -350,7 +350,7 @@ public class CDSAccountValidationUtilsTest {
         HttpClient client = Mockito.mock(HttpClient.class);
 
         Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenThrow(new java.io.IOException("Connection refused"));
+                .thenThrow(new IOException("Connection refused"));
 
         CDSAccountValidationUtils.setHttpClient(client);
 
@@ -424,25 +424,6 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-     * Verifies blank or null primary user IDs short-circuit with an empty blocked-account result.
-     */
-    @Test
-    public void testFetchBlockedSecondaryAccountsWithBlankUserId() throws CDSAccountValidationException {
-        Set<String> accounts = new HashSet<>();
-        accounts.add("acc-1");
-
-        Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
-                accounts, SECONDARY_ACCOUNTS_ENDPOINT, "", BASIC_AUTH);
-        Set<String> blockedForNull = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
-                accounts, SECONDARY_ACCOUNTS_ENDPOINT, null, BASIC_AUTH);
-
-        Assert.assertNotNull(blockedForBlank);
-        Assert.assertNotNull(blockedForNull);
-        Assert.assertTrue(blockedForBlank.isEmpty());
-        Assert.assertTrue(blockedForNull.isEmpty());
-    }
-
-    /**
      * Verifies both accountIds and userId query parameters are included for secondary-account requests.
      */
     @Test
@@ -504,16 +485,57 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertFalse(blocked.contains("acc-active"));
     }
 
+    // ---- fetchBlockedBusinessAccountsFromService tests ----
+
+    @Test
+    public void testFetchBlockedBusinessAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
+        String businessStakeholdersEndpoint = ACCOUNT_METADATA_WEBAPP_BASE_URL + "/business-stakeholders";
+
+        Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                Collections.emptySet(), businessStakeholdersEndpoint, "user-1", BASIC_AUTH);
+        Set<String> blockedForNull = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                null, businessStakeholdersEndpoint, "user-1", BASIC_AUTH);
+
+        Assert.assertNotNull(blockedForEmpty);
+        Assert.assertNotNull(blockedForNull);
+        Assert.assertTrue(blockedForEmpty.isEmpty());
+        Assert.assertTrue(blockedForNull.isEmpty());
+    }
+
+    @Test
+    public void testFetchBlockedBusinessAccountsWithBlankBasicAuth() {
+        String businessStakeholdersEndpoint = ACCOUNT_METADATA_WEBAPP_BASE_URL + "/business-stakeholders";
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                        accounts, businessStakeholdersEndpoint, "user-1", ""));
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                        accounts, businessStakeholdersEndpoint, "user-1", null));
+    }
+
     // ---- fetchAllBlockedAccounts tests ----
 
     /**
      * Verifies blocked-account results from DOMS and secondary-account checks are merged.
      */
     @Test
+    public void testFetchAllBlockedAccountsWithEmptyInput() throws CDSAccountValidationException {
+        Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                Collections.emptySet(), ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH);
+        Assert.assertNotNull(blocked);
+        Assert.assertTrue(blocked.isEmpty());
+    }
+
+    @Test
     public void testFetchAllBlockedAccountsCombinesResults() throws Exception {
         HttpClient client = Mockito.mock(HttpClient.class);
         HttpResponse<String> disclosureResponse = Mockito.mock(HttpResponse.class);
         HttpResponse<String> secondaryResponse = Mockito.mock(HttpResponse.class);
+        HttpResponse<String> businessResponse = Mockito.mock(HttpResponse.class);
 
         Mockito.when(disclosureResponse.statusCode()).thenReturn(200);
         Mockito.when(disclosureResponse.body()).thenReturn("["
@@ -523,9 +545,14 @@ public class CDSAccountValidationUtilsTest {
         Mockito.when(secondaryResponse.body()).thenReturn("["
                 + "{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"inactive\"}"
                 + "]");
+        Mockito.when(businessResponse.statusCode()).thenReturn(200);
+        Mockito.when(businessResponse.body()).thenReturn("["
+                + "{\"accountId\":\"acc-3\",\"permission\":\"VIEW\"}"
+                + "]");
         Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
                 .thenReturn(disclosureResponse)
-                .thenReturn(secondaryResponse);
+                .thenReturn(secondaryResponse)
+                .thenReturn(businessResponse);
 
         CDSAccountValidationUtils.setHttpClient(client);
 
@@ -533,14 +560,16 @@ public class CDSAccountValidationUtilsTest {
         accounts.add("acc-1");
         accounts.add("acc-2");
         accounts.add("acc-3");
+        accounts.add("acc-4");
 
         Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
                 accounts, ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH);
 
-        Assert.assertEquals(blocked.size(), 2);
+        Assert.assertEquals(blocked.size(), 3);
         Assert.assertTrue(blocked.contains("acc-1"));
         Assert.assertTrue(blocked.contains("acc-2"));
-        Assert.assertFalse(blocked.contains("acc-3"));
+        Assert.assertTrue(blocked.contains("acc-3"));
+        Assert.assertFalse(blocked.contains("acc-4"));
     }
 
     // ---- generateJWT tests ----


### PR DESCRIPTION
## Add CDS Policy to Filter BNR-Blocked Accounts from Account Resource API

> This pull request introduces a CDS policy enhancement to support the BNR feature in CDS Toolkit 2.0.

The implementation ensures that only accounts with valid and active secondary user instructions are considered during account resource API responses. This aligns with CDS compliance requirements by enforcing permission and preventing unauthorized access to account data by non-nominated users.

The update improves consent enforcement and strengthens data governance by ensuring only properly authorized representatives can access account information during retrieval operations.


------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [x] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).

