### PR TITLE
Implement Ceasing secondary user sharing feature support for CDS Toolkit 2.0

### DIFF
--- a/components/account-metadata-service/pom.xml
+++ b/components/account-metadata-service/pom.xml
@@ -233,8 +233,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>10</source>
-          <target>10</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
     </plugins>

--- a/components/account-metadata-service/pom.xml
+++ b/components/account-metadata-service/pom.xml
@@ -92,6 +92,13 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -124,7 +131,17 @@
       <version>${jackson.annotations.version}</version>
       <scope>compile</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.core.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.databind.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -212,6 +229,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>10</source>
+          <target>10</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <properties>
@@ -222,6 +247,9 @@
     <org.json.version>20231013</org.json.version>
     <testng.version>7.7.0</testng.version>
     <commons.codec.version>1.21.0</commons.codec.version>
-    <jackson.annotations.version>2.19.2</jackson.annotations.version>
+    <jackson.annotations.version>2.13.4</jackson.annotations.version>
+    <jackson.core.version>2.21.1</jackson.core.version>
+    <jackson.databind.version>2.13.4.2</jackson.databind.version>
+    <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
   </properties>
 </project>

--- a/components/account-metadata-service/src/gen/java/org/wso2/openbanking/consumerdatastandards/account/metadata/api/CeasingSecondaryUserSharing.java
+++ b/components/account-metadata-service/src/gen/java/org/wso2/openbanking/consumerdatastandards/account/metadata/api/CeasingSecondaryUserSharing.java
@@ -1,0 +1,58 @@
+package org.wso2.openbanking.consumerdatastandards.account.metadata.api;
+
+import org.wso2.openbanking.consumerdatastandards.account.metadata.impl.CeasingSecondaryUserSharingApiImpl;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.ErrorResponse;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.LegalEntitySharingItem;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.*;
+
+import java.util.List;
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+
+/**
+ * Represents a collection of functions to interact with the API endpoints.
+ */
+@Path("/legal-entity")
+@Api(description = "the legal-entity API")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", date = "2026-03-19T12:03:46.119117500+05:30[Asia/Colombo]", comments = "Generator version: 7.19.0")
+public class CeasingSecondaryUserSharing {
+
+    @GET
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Get legal entity sharing statuses for one user across multiple accounts", notes = "Retrieve legal entity sharing statuses (blocked or active) for a given user ID and multiple account IDs (comma-separated).", response = LegalEntitySharingItem.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "OAuth2", scopes = {
+            }),
+
+            @Authorization(value = "BasicAuth")
+    }, tags={ "CeasingSecondaryUserShare" })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Legal entity sharing statuses retrieved successfully", response = LegalEntitySharingItem.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "Bad Request", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Server Error", response = ErrorResponse.class)
+    })
+        public Response getLegalEntitySharingStatusGet(@QueryParam("userId") @NotBlank @ApiParam("User ID")  String userId, @QueryParam("accountIds") @NotBlank  @ApiParam("Comma-separated account IDs")  String accountIds, @QueryParam("clientId") @NotBlank @ApiParam("Software product client ID to resolve legal entity ID")  String clientId) {
+                return CeasingSecondaryUserSharingApiImpl.getLegalEntitySharingStatus(accountIds, userId, clientId);
+    }
+
+    @POST
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "Update legal entity sharing statuses for one or more records", notes = "Update legal entity sharing status records identified by the (secondaryUserID, accountID) pair. If legalEntitySharingStatus is blocked, legalEntityID is added to the fs_secondary_user.BLOCKED_ENTITIES column. If a record already exists, legalEntityID values are appended with a preceding ','. If legalEntitySharingStatus is active, legalEntityID is removed from the BLOCKED_ENTITIES string. ", response = LegalEntitySharingItem.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "OAuth2", scopes = {
+            }),
+
+            @Authorization(value = "BasicAuth")
+    }, tags={ "CeasingSecondaryUserShare" })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Legal entity sharing statuses updated successfully", response = LegalEntitySharingItem.class, responseContainer = "List"),
+            @ApiResponse(code = 400, message = "Bad Request", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Server Error", response = ErrorResponse.class)
+    })
+    public Response updateLegalEntitySharingStatusPost(@Valid @NotNull List<@Valid LegalEntitySharingItem> legalEntitySharingItem) {
+                return CeasingSecondaryUserSharingApiImpl.updateLegalEntitySharingStatus(legalEntitySharingItem);
+    }
+}

--- a/components/account-metadata-service/src/gen/java/org/wso2/openbanking/consumerdatastandards/account/metadata/api/SecondaryAccountsApi.java
+++ b/components/account-metadata-service/src/gen/java/org/wso2/openbanking/consumerdatastandards/account/metadata/api/SecondaryAccountsApi.java
@@ -55,22 +55,4 @@ public class SecondaryAccountsApi {
     public Response getSecondaryAccountsInstructionStatusGet(@QueryParam("accountIds") @NotNull  @ApiParam("Comma-separated account IDs")  String accountIds,@QueryParam("userId") @NotNull  @ApiParam("User ID")  String userId) {
         return SecondaryAccountsManagementApiImpl.getSecondaryAccountInstructions(accountIds, userId);
     }
-
-    @PUT
-    @Consumes({ "application/json" })
-    @Produces({ "application/json" })
-    @ApiOperation(value = "Update secondary accounts instruction status for one or more accounts", notes = "This API is used to update the CDS Secondary Accounts Instruction and Privilege Status.", response = SecondaryAccountInstructionItem.class, responseContainer = "List", authorizations = {
-            @Authorization(value = "OAuth2", scopes = {
-            }),
-
-            @Authorization(value = "BasicAuth")
-    }, tags={ "Secondary User Instruction" })
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Secondary accounts instruction status successfully updated", response = SecondaryAccountInstructionItem.class, responseContainer = "List"),
-            @ApiResponse(code = 400, message = "Bad Request", response = ErrorResponse.class),
-            @ApiResponse(code = 500, message = "Server Error", response = ErrorResponse.class)
-    })
-    public Response updateSecondaryAccountStatusPut(@Valid @NotNull List<@Valid SecondaryAccountInstructionItem> secondaryAccountInstructionItem) {
-        return SecondaryAccountsManagementApiImpl.updateSecondaryAccountInstructions(secondaryAccountInstructionItem);
-    }
 }

--- a/components/account-metadata-service/src/gen/java/org/wso2/openbanking/consumerdatastandards/account/metadata/model/LegalEntitySharingItem.java
+++ b/components/account-metadata-service/src/gen/java/org/wso2/openbanking/consumerdatastandards/account/metadata/model/LegalEntitySharingItem.java
@@ -1,0 +1,208 @@
+package org.wso2.openbanking.consumerdatastandards.account.metadata.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+
+@JsonTypeName("LegalEntitySharingItem")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", date = "2026-04-05T16:27:34.461315+05:30[Asia/Colombo]", comments = "Generator version: 7.21.0")
+public class LegalEntitySharingItem   {
+  private String secondaryUserID;
+  private String accountID;
+  private String legalEntityID;
+  public enum LegalEntitySharingStatusEnum {
+
+    blocked(String.valueOf("blocked")), active(String.valueOf("active"));
+
+
+    private String value;
+
+    LegalEntitySharingStatusEnum (String v) {
+      value = v;
+    }
+
+    public String value() {
+      return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    /**
+     * Convert a String into String, as specified in the
+     * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
+     */
+    public static LegalEntitySharingStatusEnum fromString(String s) {
+      for (LegalEntitySharingStatusEnum b : LegalEntitySharingStatusEnum.values()) {
+        // using Objects.toString() to be safe if value type non-object type
+        // because types like 'int' etc. will be auto-boxed
+        if (Objects.toString(b.value).equals(s)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected string value '" + s + "'");
+    }
+
+    @JsonCreator
+    public static LegalEntitySharingStatusEnum fromValue(String value) {
+      for (LegalEntitySharingStatusEnum b : LegalEntitySharingStatusEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+  }
+
+  private LegalEntitySharingStatusEnum legalEntitySharingStatus;
+
+  public LegalEntitySharingItem() {
+  }
+
+  @JsonCreator
+  public LegalEntitySharingItem(
+          @JsonProperty(required = true, value = "secondaryUserID") String secondaryUserID,
+          @JsonProperty(required = true, value = "accountID") String accountID,
+          @JsonProperty(required = true, value = "legalEntityID") String legalEntityID,
+          @JsonProperty(required = true, value = "legalEntitySharingStatus") LegalEntitySharingStatusEnum legalEntitySharingStatus
+  ) {
+    this.secondaryUserID = secondaryUserID;
+    this.accountID = accountID;
+    this.legalEntityID = legalEntityID;
+    this.legalEntitySharingStatus = legalEntitySharingStatus;
+  }
+
+  /**
+   * Secondary user identifier. Together with accountID, this uniquely identifies a record in fs_secondary_user.
+   **/
+  public LegalEntitySharingItem secondaryUserID(String secondaryUserID) {
+    this.secondaryUserID = secondaryUserID;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "secondary.user@example.com", required = true, value = "Secondary user identifier. Together with accountID, this uniquely identifies a record in fs_secondary_user.")
+  @JsonProperty(required = true, value = "secondaryUserID")
+  @NotBlank public String getSecondaryUserID() {
+    return secondaryUserID;
+  }
+
+  @JsonProperty(required = true, value = "secondaryUserID")
+  public void setSecondaryUserID(String secondaryUserID) {
+    this.secondaryUserID = secondaryUserID;
+  }
+
+  /**
+   * Account ID
+   **/
+  public LegalEntitySharingItem accountID(String accountID) {
+    this.accountID = accountID;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "acc-12345", required = true, value = "Account ID")
+  @JsonProperty(required = true, value = "accountID")
+  @NotBlank public String getAccountID() {
+    return accountID;
+  }
+
+  @JsonProperty(required = true, value = "accountID")
+  public void setAccountID(String accountID) {
+    this.accountID = accountID;
+  }
+
+  /**
+   * Legal entity identifier
+   **/
+  public LegalEntitySharingItem legalEntityID(String legalEntityID) {
+    this.legalEntityID = legalEntityID;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "le-001", required = true, value = "Legal entity identifier")
+  @JsonProperty(required = true, value = "legalEntityID")
+  @NotBlank public String getLegalEntityID() {
+    return legalEntityID;
+  }
+
+  @JsonProperty(required = true, value = "legalEntityID")
+  public void setLegalEntityID(String legalEntityID) {
+    this.legalEntityID = legalEntityID;
+  }
+
+  /**
+   * Legal entity sharing status. blocked adds legalEntityID to BLOCKED_ENTITIES, active removes legalEntityID from BLOCKED_ENTITIES.
+   **/
+  public LegalEntitySharingItem legalEntitySharingStatus(LegalEntitySharingStatusEnum legalEntitySharingStatus) {
+    this.legalEntitySharingStatus = legalEntitySharingStatus;
+    return this;
+  }
+
+
+  @ApiModelProperty(example = "active", required = true, value = "Legal entity sharing status. blocked adds legalEntityID to BLOCKED_ENTITIES, active removes legalEntityID from BLOCKED_ENTITIES.")
+  @JsonProperty(required = true, value = "legalEntitySharingStatus")
+  @NotNull public LegalEntitySharingStatusEnum getLegalEntitySharingStatus() {
+    return legalEntitySharingStatus;
+  }
+
+  @JsonProperty(required = true, value = "legalEntitySharingStatus")
+  public void setLegalEntitySharingStatus(LegalEntitySharingStatusEnum legalEntitySharingStatus) {
+    this.legalEntitySharingStatus = legalEntitySharingStatus;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LegalEntitySharingItem legalEntitySharingItem = (LegalEntitySharingItem) o;
+    return Objects.equals(this.secondaryUserID, legalEntitySharingItem.secondaryUserID) &&
+            Objects.equals(this.accountID, legalEntitySharingItem.accountID) &&
+            Objects.equals(this.legalEntityID, legalEntitySharingItem.legalEntityID) &&
+            Objects.equals(this.legalEntitySharingStatus, legalEntitySharingItem.legalEntitySharingStatus);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(secondaryUserID, accountID, legalEntityID, legalEntitySharingStatus);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class LegalEntitySharingItem {\n");
+
+    sb.append("    secondaryUserID: ").append(toIndentedString(secondaryUserID)).append("\n");
+    sb.append("    accountID: ").append(toIndentedString(accountID)).append("\n");
+    sb.append("    legalEntityID: ").append(toIndentedString(legalEntityID)).append("\n");
+    sb.append("    legalEntitySharingStatus: ").append(toIndentedString(legalEntitySharingStatus)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+
+
+}

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/configurations/ConfigurableProperties.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/configurations/ConfigurableProperties.java
@@ -57,6 +57,6 @@ public class ConfigurableProperties {
     public static final String IS_ADMIN_PASSWORD = "<IS_ADMIN_PASSWORD>";
 
     // HTTP timeouts (ms)
-    public static final int ACCELERATOR_CONNECT_TIMEOUT_MILLIS = 5000;
-    public static final int ACCELERATOR_SOCKET_TIMEOUT_MILLIS  = 10000;
+    public static final int CONNECT_TIMEOUT_MILLIS = 5000;
+    public static final int SOCKET_TIMEOUT_MILLIS = 10000;
 }

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/configurations/ConfigurableProperties.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/configurations/ConfigurableProperties.java
@@ -25,4 +25,38 @@ public class ConfigurableProperties {
 
     public static final String ACCOUNT_METADATA_DATASOURCE_JNDI_NAME = "jdbc/ACCOUNT_METADATA_DB";
 
+    /** User credentials for authenticating against the IS server when resolving a client ID to its legal entity ID. */
+    public static final String IS_USERNAME = "<IS_ADMIN_USERNAME>";
+    public static final String IS_PASSWORD = "<IS_ADMIN_PASSWORD>";
+    public static final String IS_APPLICATIONS_ENDPOINT = "https://<IS_HOST>:9446/api/server/v1/applications";
+
+    // Accelerator token endpoint
+    public static final String ACCELERATOR_TOKEN_ENDPOINT_URL =
+            "https://<IS_HOST>:9446/oauth2/token";
+
+    // Accelerator consent admin search endpoint
+    public static final String ACCELERATOR_CONSENT_SEARCH_URL =
+            "https://<IS_HOST>:9446/api/fs/consent/admin/search";
+
+    // OAuth2 client credentials (Basic Auth for token request)
+    public static final String ACCOUNT_METADATA_CLIENT_APP_ID = "<ACCOUNT_METADATA_CLIENT_APP_ID>";
+    public static final String ACCOUNT_METADATA_CLIENT_APP_SECRET =
+            "<ACCOUNT_METADATA_CLIENT_APP_SECRET>";
+
+    // Resource-owner credentials and scope for password grant
+    public static final String CUSTOMER_CARE_OFFICER_USERNAME = "<CUSTOMER_CARE_OFFICER_USERNAME>";
+    public static final String CUSTOMER_CARE_OFFICER_PASSWORD = "<CUSTOMER_CARE_OFFICER_PASSWORD>";
+    public static final String CUSTOMER_CARE_OFFICER_TOKEN_SCOPE = "consents:read_all";
+
+    // Accelerator consent update (expire) endpoint base URL
+    public static final String ACCELERATOR_CONSENT_UPDATE_BASE_URL =
+            "https://<IS_HOST>:9446/api/fs/consent/manage/account-access-consents";
+
+    // Admin credentials for Basic Auth on the consent update endpoint
+    public static final String IS_ADMIN_USERNAME = "<IS_ADMIN_USERNAME>";
+    public static final String IS_ADMIN_PASSWORD = "<IS_ADMIN_PASSWORD>";
+
+    // HTTP timeouts (ms)
+    public static final int ACCELERATOR_CONNECT_TIMEOUT_MILLIS = 5000;
+    public static final int ACCELERATOR_SOCKET_TIMEOUT_MILLIS  = 10000;
 }

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/constants/CommonConstants.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/constants/CommonConstants.java
@@ -30,10 +30,69 @@ public class CommonConstants {
     // Constants Related to Secondary Accounts
     public static final String SUI_ACTIVE_STATUS = "active";
     public static final String SUI_INACTIVE_STATUS = "inactive";
+    public static final String LEGAL_ENTITY_SHARING_STATUS_BLOCKED = "blocked";
+    public static final String LEGAL_ENTITY_SHARING_STATUS_ACTIVE = "active";
 
     // Constants Related to Business Stakeholders
     public static final String BNR_PERMISSION_AUTHORIZE = "AUTHORIZE";
     public static final String BNR_PERMISSION_REVOKE = "REVOKE";
     public static final String BNR_PERMISSION_VIEW = "VIEW";
+
+    // IS Applications endpoint constants
+    public static final String FILTER_TAG = "filter";
+    public static final String ATTRIBUTES_TAG = "attributes";
+    public static final String CLIENT_ID_FILTER_PREFIX = "clientId eq ";
+    public static final String ADVANCED_CONFIGURATIONS_TAG = "advancedConfigurations";
+    public static final String APPLICATIONS_TAG = "applications";
+    public static final String ADDITIONAL_SP_PROPERTIES_TAG = "additionalSpProperties";
+    public static final String PROPERTY_NAME_TAG = "name";
+    public static final String PROPERTY_VALUE_TAG = "value";
+    public static final String LEGAL_ENTITY_ID_PROPERTY_NAME = "legal_entity_id";
+
+    // HTTP constants
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String BASIC_TAG = "Basic ";
+    public static final String JSON_CONTENT_TYPE = "application/json";
+    public static final String ACCEPT_TAG = "Accept";
+
+    // HTTP headers
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
+    public static final String ACCEPT_HEADER = "Accept";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String BASIC_PREFIX = "Basic ";
+    public static final String CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+    public static final String CONTENT_TYPE_JSON = "application/json";
+
+    // OAuth2 form parameter names
+    public static final String PARAM_GRANT_TYPE = "grant_type";
+    public static final String PARAM_USERNAME = "username";
+    public static final String PARAM_PASSWORD = "password";
+    public static final String PARAM_SCOPE = "scope";
+    public static final String GRANT_TYPE_PASSWORD = "password";
+
+    // Token response JSON field
+    public static final String TOKEN_RESPONSE_ACCESS_TOKEN = "access_token";
+
+    // Consent search query parameter names
+    public static final String CONSENT_SEARCH_PARAM_CONSENT_TYPES = "consentTypes";
+    public static final String CONSENT_SEARCH_PARAM_USER_IDS = "userIds";
+    public static final String CONSENT_TYPE_ACCOUNTS = "accounts";
+
+    // Consent search response JSON field names
+    // Verify these against the live API response and adjust constants if the shape differs.
+    public static final String CONSENT_RESPONSE_DATA = "data";
+    public static final String CONSENT_RESPONSE_CONSENT_ID = "consentId";
+    public static final String CONSENT_RESPONSE_CLIENT_ID  = "clientId";
+
+    // Consent update (expire) request headers
+    public static final String HEADER_WSO2_CLIENT_ID = "x-wso2-client-id";
+    public static final String HEADER_WSO2_INTERNAL_REQUEST = "x-wso2-internal-request";
+    public static final String HEADER_FAPI_INTERACTION_ID  = "x-fapi-interaction-id";
+    public static final String WSO2_INTERNAL_REQUEST_VALUE = "true";
+
+    // Consent update request body field names
+    public static final String CONSENT_UPDATE_STATUS = "status";
+    public static final String CONSENT_EXPIRE_STATUS = "Expired";
 
 }

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/error/AccountMetadataThrowableMapper.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/error/AccountMetadataThrowableMapper.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.ErrorResponse;
 
 import javax.validation.ConstraintViolationException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -40,6 +41,26 @@ public class AccountMetadataThrowableMapper implements ExceptionMapper<Throwable
 
     @Override
     public Response toResponse(Throwable throwable) {
+
+        WebApplicationException webApplicationException = findWebApplicationException(throwable);
+        if (webApplicationException != null) {
+            Response response = webApplicationException.getResponse();
+            int statusCode = response != null ? response.getStatus()
+                : Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+            String message = webApplicationException.getMessage();
+            if (message == null || message.trim().isEmpty()) {
+            message = response != null && response.getStatusInfo() != null
+                ? response.getStatusInfo().getReasonPhrase()
+                : "Request failed";
+            }
+
+            log.warn("[AccountMetadata] WebApplicationException mapped with status " + statusCode +
+                ": " + message);
+            return Response.status(statusCode)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(new ErrorResponse().errorDescription(message))
+                .build();
+        }
 
         Throwable cause = throwable;
         while (cause != null) {
@@ -74,9 +95,35 @@ public class AccountMetadataThrowableMapper implements ExceptionMapper<Throwable
     }
 
     /**
-     * Checks if a throwable is an instance of the given class by name, tolerating classloader boundaries.
-     * Using Class.getName() instead of instanceof handles the case where the exception is thrown by a class
-     * loaded in a different classloader (e.g. the server's OSGi Jackson bundle vs the WAR's WEB-INF/lib copy).
+     * Search the causal chain for a {@link WebApplicationException} and return it if found.
+     * This allows existing JAX-RS exceptions to be mapped through transparently.
+     *
+     * @param throwable the root throwable to inspect
+     * @return the first {@link WebApplicationException} found in the cause chain, or {@code null}
+     *         if none is present
+     */
+    private static WebApplicationException findWebApplicationException(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (cause instanceof WebApplicationException) {
+                return (WebApplicationException) cause;
+            }
+            cause = cause.getCause();
+        }
+        return null;
+    }
+
+    /**
+     * Determine whether the provided {@code throwable} is an instance of the given
+     * {@code targetClass}, comparing by class name to tolerate classloader boundaries.
+     *
+     * <p>Using the class name rather than {@code instanceof} allows detection of
+     * exception types that may have been loaded by a different classloader (common
+     * in servlet/OSGi environments).</p>
+     *
+     * @param throwable the throwable to inspect
+     * @param targetClass the exception class to match (by name)
+     * @return {@code true} if the throwable is an instance of {@code targetClass}
      */
     private static boolean isCausedBy(Throwable throwable, Class<?> targetClass) {
         String targetName = targetClass.getName();

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/BusinessStakeholdersManagementApiImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/BusinessStakeholdersManagementApiImpl.java
@@ -228,13 +228,10 @@ public class BusinessStakeholdersManagementApiImpl {
                     .collect(Collectors.toList());
 
             if (!missingItems.isEmpty()) {
-                String missingPairs = missingItems.stream()
-                        .map(item -> "accountId=" + item.getAccountId() + ", userId=" + item.getUserId())
-                        .collect(Collectors.joining("; "));
-                log.error("[Business Stakeholders] No records found for: " + missingPairs);
+                log.error("[Business Stakeholders] No records found for requested items");
                 return Response.status(Response.Status.NOT_FOUND)
-                        .entity(new ErrorResponse().errorDescription("No records found for: " + missingPairs))
-                        .build();
+                    .entity(new ErrorResponse().errorDescription("No records found for requested items"))
+                    .build();
             }
 
             List<BusinessStakeholderPermissionItem> itemsToRevoke = validItems.stream()

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/BusinessStakeholdersManagementApiImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/BusinessStakeholdersManagementApiImpl.java
@@ -223,6 +223,20 @@ public class BusinessStakeholdersManagementApiImpl {
             Set<String> existingKeys = existingItems.stream().map(BusinessStakeholdersManagementApiImpl::buildKey)
                     .collect(Collectors.toSet());
 
+            List<BusinessStakeholderPermissionItem> missingItems = validItems.stream()
+                    .filter(item -> !existingKeys.contains(buildKey(item)))
+                    .collect(Collectors.toList());
+
+            if (!missingItems.isEmpty()) {
+                String missingPairs = missingItems.stream()
+                        .map(item -> "accountId=" + item.getAccountId() + ", userId=" + item.getUserId())
+                        .collect(Collectors.joining("; "));
+                log.error("[Business Stakeholders] No records found for: " + missingPairs);
+                return Response.status(Response.Status.NOT_FOUND)
+                        .entity(new ErrorResponse().errorDescription("No records found for: " + missingPairs))
+                        .build();
+            }
+
             List<BusinessStakeholderPermissionItem> itemsToRevoke = validItems.stream()
                 .filter(item -> existingKeys.contains(buildKey(item)))
                 .map(item -> new BusinessStakeholderPermissionItem(
@@ -305,9 +319,6 @@ public class BusinessStakeholdersManagementApiImpl {
             }
 
             String accountId = StringUtils.trimToEmpty(requestItem.getAccountID());
-            if (StringUtils.isBlank(accountId)) {
-                throw new AccountMetadataException("accountID is required");
-            }
 
             List<String> accountOwners = requestItem.getAccountOwners();
             // Add account owners with VIEW permission
@@ -374,9 +385,6 @@ public class BusinessStakeholdersManagementApiImpl {
             }
 
             String accountId = StringUtils.trimToEmpty(requestItem.getAccountID());
-            if (StringUtils.isBlank(accountId)) {
-                throw new AccountMetadataException("accountID is required");
-            }
 
             List<String> accountOwners = requestItem.getAccountOwners();
             if (accountOwners != null) {

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/CeasingSecondaryUserSharingApiImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/CeasingSecondaryUserSharingApiImpl.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.openbanking.consumerdatastandards.account.metadata.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.configurations.ConfigurableProperties;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.constants.CommonConstants;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.exceptions.AccountMetadataException;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.ErrorResponse;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.LegalEntitySharingItem;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.service.core.AccountMetadataService;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.service.core.AccountMetadataServiceImpl;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Implementation for legal entity sharing API operations.
+ */
+public class CeasingSecondaryUserSharingApiImpl {
+
+    private static final Log log = LogFactory.getLog(CeasingSecondaryUserSharingApiImpl.class);
+
+    private static final AccountMetadataService accountMetadataService = AccountMetadataServiceImpl.getInstance();
+
+    private static final CloseableHttpClient httpClient;
+    private static final String IS_BASIC_AUTH_HEADER;
+
+    private static final long LEGAL_ENTITY_CACHE_TTL_MS = TimeUnit.HOURS.toMillis(1);
+    private static final Map<String, LegalEntityCacheEntry> LEGAL_ENTITY_CACHE = new ConcurrentHashMap<>();
+
+    private static class LegalEntityCacheEntry {
+        final String legalEntityId;
+        final long expiryMs;
+
+        LegalEntityCacheEntry(String legalEntityId) {
+            this.legalEntityId = legalEntityId;
+            this.expiryMs = System.currentTimeMillis() + LEGAL_ENTITY_CACHE_TTL_MS;
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() > expiryMs;
+        }
+    }
+
+    static {
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(5000)
+                .setSocketTimeout(10000)
+                .build();
+        httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+
+        String credentials = ConfigurableProperties.IS_USERNAME + ":" + ConfigurableProperties.IS_PASSWORD;
+        IS_BASIC_AUTH_HEADER = CommonConstants.BASIC_TAG
+                + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private CeasingSecondaryUserSharingApiImpl() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Updates legal entity sharing statuses for one or more account-user records.
+     * Items with status {@code blocked} are inserted into fs_account_blocked_legal_entity (idempotent upsert).
+     * Items with status {@code active} delete the corresponding row if it exists.
+     *
+     * @param request list of legal entity sharing records to update
+     * @return response with list of processed records
+     */
+    public static Response updateLegalEntitySharingStatus(List<LegalEntitySharingItem> request) {
+
+        List<LegalEntitySharingItem> validItems;
+        try {
+            validItems = validateRequest(request);
+        } catch (AccountMetadataException e) {
+            return sendBadRequest(e.getMessage());
+        }
+
+        try {
+            if (validItems.isEmpty()) {
+                return Response.status(Response.Status.OK).entity(new ArrayList<>()).build();
+            }
+
+            accountMetadataService.upsertBatchLegalEntitySharingStatuses(validItems);
+            return Response.status(Response.Status.OK).entity(validItems).build();
+
+        } catch (AccountMetadataException e) {
+            log.error("[Legal Entity Sharing] Failed to update legal entity sharing statuses", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new ErrorResponse().errorDescription(
+                            "Failed to update legal entity sharing statuses: " + e.getMessage()))
+                    .build();
+        }
+    }
+
+    /**
+     * Retrieves blocked legal entity sharing records for one user and multiple accounts.
+     * When {@code clientId} is provided, the legal entity ID is resolved from the IS server and only rows
+     * matching that legal entity are returned.
+     *
+     * @param accountIds comma-separated account IDs
+     * @param userId     user ID
+     * @param clientId   software product client ID to resolve the legal entity ID
+     * @return response with blocked legal entity sharing records
+     */
+    public static Response getLegalEntitySharingStatus(String accountIds, String userId, String clientId) {
+
+        if (StringUtils.isBlank(clientId)) {
+            return sendBadRequest("clientId is required");
+        }
+
+        List<String> accountIdList = Arrays.stream(accountIds.split(",")).map(StringUtils::trimToEmpty)
+            .filter(StringUtils::isNotBlank).distinct().collect(Collectors.toList());
+
+        // Resolve the legal entity ID from IS when a clientId is supplied
+        String resolvedLegalEntityId = null;
+        try {
+            resolvedLegalEntityId = resolveLegalEntityId(clientId);
+            if (StringUtils.isBlank(resolvedLegalEntityId)) {
+                throw new AccountMetadataException("No legal entity ID found for clientId: " + clientId);
+            }
+        } catch (AccountMetadataException e) {
+            log.error("[Legal Entity Sharing] Failed to resolve legal entity ID for clientId: " + clientId, e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new ErrorResponse().errorDescription(
+                            "Failed to resolve legal entity ID: " + e.getMessage()))
+                    .build();
+        }
+
+        try {
+            String normalizedUserId = StringUtils.trimToEmpty(userId);
+            List<Pair<String, String>> accountUserPairs = new ArrayList<>();
+            for (String accountId : accountIdList) {
+                accountUserPairs.add(Pair.of(accountId, normalizedUserId));
+            }
+
+            List<LegalEntitySharingItem> items =
+                    accountMetadataService.getBatchLegalEntitySharingStatuses(accountUserPairs);
+
+            final String filterEntityId = resolvedLegalEntityId;
+            Map<String, LegalEntitySharingItem.LegalEntitySharingStatusEnum> statusByAccount =
+                    new LinkedHashMap<>();
+            for (String accountId : accountIdList) {
+                statusByAccount.put(accountId, LegalEntitySharingItem.LegalEntitySharingStatusEnum.active);
+            }
+
+            for (LegalEntitySharingItem item : items) {
+                if (item == null || !filterEntityId.equalsIgnoreCase(item.getLegalEntityID())) {
+                    continue;
+                }
+                if (statusByAccount.containsKey(item.getAccountID())) {
+                    statusByAccount.put(item.getAccountID(), item.getLegalEntitySharingStatus());
+                }
+            }
+
+            List<LegalEntitySharingItem> responseItems = new ArrayList<>();
+            for (String accountId : accountIdList) {
+                LegalEntitySharingItem responseItem = new LegalEntitySharingItem();
+                responseItem.setAccountID(accountId);
+                responseItem.setSecondaryUserID(normalizedUserId);
+                responseItem.setLegalEntityID(filterEntityId);
+                responseItem.setLegalEntitySharingStatus(statusByAccount.get(accountId));
+                responseItems.add(responseItem);
+            }
+            items = responseItems;
+
+            return Response.status(Response.Status.OK).entity(items).build();
+
+        } catch (AccountMetadataException e) {
+            log.error("[Legal Entity Sharing] Failed to retrieve legal entity sharing statuses", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new ErrorResponse().errorDescription(
+                            "Failed to retrieve legal entity sharing statuses: " + e.getMessage()))
+                    .build();
+        }
+    }
+
+    /**
+     * Returns the legal entity ID for the given client ID, using a 1-hour in-memory cache to avoid
+     * repeated calls to the IS server.
+     *
+     * @param clientId software product client ID
+     * @return legal entity ID
+     */
+    private static String resolveLegalEntityId(String clientId) throws AccountMetadataException {
+        LegalEntityCacheEntry cached = LEGAL_ENTITY_CACHE.get(clientId);
+        
+        if (cached != null && !cached.isExpired()) {
+            return cached.legalEntityId;
+        }
+        String legalEntityId = fetchLegalEntityIdByClientId(clientId);
+        LEGAL_ENTITY_CACHE.put(clientId, new LegalEntityCacheEntry(legalEntityId));
+
+        return legalEntityId;
+    }
+
+    /**
+     * Calls the IS applications endpoint to resolve the legal entity ID for the given client ID.
+     * Uses credentials from {@link ConfigurableProperties}.
+     *
+     * @param clientId software product client ID
+     * @return legal entity ID, or empty string if not found
+     */
+    private static String fetchLegalEntityIdByClientId(String clientId) throws AccountMetadataException {
+
+        try {
+            String filterParam = URLEncoder.encode(
+                    CommonConstants.CLIENT_ID_FILTER_PREFIX + clientId, StandardCharsets.UTF_8);
+            String attributesParam = URLEncoder.encode(
+                    CommonConstants.ADVANCED_CONFIGURATIONS_TAG, StandardCharsets.UTF_8);
+            String requestUrl = ConfigurableProperties.IS_APPLICATIONS_ENDPOINT + "?" + CommonConstants.FILTER_TAG + "="
+                    + filterParam + "&" + CommonConstants.ATTRIBUTES_TAG + "=" + attributesParam;
+
+            HttpGet request = new HttpGet(requestUrl);
+            request.addHeader(CommonConstants.ACCEPT_TAG, CommonConstants.JSON_CONTENT_TYPE);
+            request.addHeader(CommonConstants.AUTH_HEADER, IS_BASIC_AUTH_HEADER);
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode != 200) {
+                    String errorMessage = "IS applications service returned HTTP " + statusCode;
+                    log.error(errorMessage);
+                    throw new AccountMetadataException(errorMessage);
+                }
+
+                String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                return parseLegalEntityIdFromIsResponse(responseBody);
+            }
+        } catch (IOException e) {
+            String errorMessage = "[LegalEntity] Error calling IS applications service";
+            log.error(errorMessage, e);
+            throw new AccountMetadataException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Parses the legal entity ID from the IS applications service response body.
+     *
+     * @param responseBody the JSON response body as a string
+     * @return the legal entity ID if found, or an empty string if not present
+     * @throws AccountMetadataException if the response is malformed
+     */
+    private static String parseLegalEntityIdFromIsResponse(String responseBody) throws AccountMetadataException {
+
+        JSONObject responseJson;
+        try {
+            responseJson = new JSONObject(responseBody);
+        } catch (JSONException e) {
+            String errorMessage = "Invalid IS applications service response for retrieving legal entity ID";
+            log.error(errorMessage, e);
+            throw new AccountMetadataException(errorMessage, e);
+        }
+
+        JSONArray applications = responseJson.optJSONArray(CommonConstants.APPLICATIONS_TAG);
+        if (applications == null || applications.length() == 0) {
+            return StringUtils.EMPTY;
+        }
+
+        JSONObject application = applications.optJSONObject(0);
+        JSONObject advancedConfigurations = application.optJSONObject(CommonConstants.ADVANCED_CONFIGURATIONS_TAG);
+        if (advancedConfigurations == null) {
+            return StringUtils.EMPTY;
+        }
+
+        JSONArray additionalSpProperties = advancedConfigurations
+                .optJSONArray(CommonConstants.ADDITIONAL_SP_PROPERTIES_TAG);
+        if (additionalSpProperties == null) {
+            String errorMessage = "No additional SP properties found in IS applications response";
+            log.error(errorMessage);
+            throw new AccountMetadataException(errorMessage);
+        }
+
+        for (int i = 0; i < additionalSpProperties.length(); i++) {
+            JSONObject property = additionalSpProperties.optJSONObject(i);
+            if (property == null) {
+                continue;
+            }
+            String name = property.optString(CommonConstants.PROPERTY_NAME_TAG, StringUtils.EMPTY);
+            if (CommonConstants.LEGAL_ENTITY_ID_PROPERTY_NAME.equalsIgnoreCase(name)) {
+                return property.optString(CommonConstants.PROPERTY_VALUE_TAG, StringUtils.EMPTY);
+            }
+        }
+
+        String errorMessage = "legal_entity_id not found in IS application additional SP properties";
+        log.error(errorMessage);
+        throw new AccountMetadataException(errorMessage);
+    }
+
+    /**
+     * Validates the incoming request items, ensuring that there are no duplicate
+     * (accountID, secondaryUserID, legalEntityID) combinations.
+     *
+     * @param request raw list of legal entity sharing items from the caller
+     * @return list of validated and trimmed items ready for processing
+     * @throws AccountMetadataException if a duplicate entry is detected
+     */
+    private static List<LegalEntitySharingItem> validateRequest(List<LegalEntitySharingItem> request)
+            throws AccountMetadataException {
+        Set<String> seenKeys = new LinkedHashSet<>();
+        List<LegalEntitySharingItem> validatedItems = new ArrayList<>();
+
+        for (LegalEntitySharingItem item : request) {
+            String accountId = StringUtils.trimToEmpty(item.getAccountID());
+            String secondaryUserId = StringUtils.trimToEmpty(item.getSecondaryUserID());
+            String legalEntityId = StringUtils.trimToEmpty(item.getLegalEntityID());
+
+            item.setAccountID(accountId);
+            item.setSecondaryUserID(secondaryUserId);
+            item.setLegalEntityID(legalEntityId);
+
+            String key = accountId + "::" + secondaryUserId + "::" + legalEntityId;
+            if (!seenKeys.add(key)) {
+                throw new AccountMetadataException("Duplicate entry for accountID=" + accountId
+                        + ", secondaryUserID=" + secondaryUserId + ", legalEntityID=" + legalEntityId);
+            }
+            validatedItems.add(item);
+        }
+
+        return validatedItems;
+    }
+
+    /**
+     * Logs the given message at error level and returns a 400 Bad Request response.
+     *
+     * @param message human-readable description of the validation error
+     * @return 400 Bad Request response containing the error description
+     */
+    private static Response sendBadRequest(String message) {
+        log.error("[Legal Entity Sharing] " + message);
+        return Response.status(Response.Status.BAD_REQUEST).entity(new ErrorResponse().errorDescription(message))
+                .build();
+    }
+}

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/CeasingSecondaryUserSharingApiImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/CeasingSecondaryUserSharingApiImpl.java
@@ -87,8 +87,8 @@ public class CeasingSecondaryUserSharingApiImpl {
 
     static {
         RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(5000)
-                .setSocketTimeout(10000)
+                .setConnectTimeout(ConfigurableProperties.CONNECT_TIMEOUT_MILLIS)
+                .setSocketTimeout(ConfigurableProperties.SOCKET_TIMEOUT_MILLIS)
                 .build();
         httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
 

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/DisclosureOptionsManagementApiImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/DisclosureOptionsManagementApiImpl.java
@@ -128,7 +128,6 @@ public class DisclosureOptionsManagementApiImpl {
         }
 
         try {
-            // Split comma-separated account IDs and trim whitespace
             List<String> accountIdList = Arrays.asList(accountIds.split(","));
             accountIdList = accountIdList.stream().map(String::trim).filter(StringUtils::isNotBlank)
                     .collect(Collectors.toList());
@@ -170,7 +169,6 @@ public class DisclosureOptionsManagementApiImpl {
             Map<String, String> accountDisclosureMap = new HashMap<>();
             List<String> accountIdsToCheck = new ArrayList<>();
 
-            // Validate and collect accounts
             for (DisclosureOptionItem item : request) {
                 String disclosureOptionStatus = item.getDisclosureOption();
                 if (isValidDOMSStatus(disclosureOptionStatus)) {
@@ -186,10 +184,8 @@ public class DisclosureOptionsManagementApiImpl {
                 }
             }
 
-            // Batch check for existing accounts
             Map<String, String> existingStatuses = accountMetadataService.getBatchDisclosureOptions(accountIdsToCheck);
 
-            // Filter to only add new accounts
             Map<String, String> newAccounts = new HashMap<>();
             for (Map.Entry<String, String> entry : accountDisclosureMap.entrySet()) {
                 if (!existingStatuses.containsKey(entry.getKey())) {

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/SecondaryAccountsManagementApiImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/impl/SecondaryAccountsManagementApiImpl.java
@@ -27,6 +27,7 @@ import org.wso2.openbanking.consumerdatastandards.account.metadata.model.ErrorRe
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.SecondaryAccountInstructionItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.service.core.AccountMetadataService;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.service.core.AccountMetadataServiceImpl;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.utils.ConsentExpiryUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,54 +50,6 @@ public class SecondaryAccountsManagementApiImpl {
 
     private SecondaryAccountsManagementApiImpl() {
         // Prevent instantiation
-    }
-
-    /**
-     * Updates secondary account instructions for multiple account-user combinations.
-     *
-     * @param request list of secondary account instruction items to update
-     * @return response with list of updated items
-     */
-    public static Response updateSecondaryAccountInstructions(List<SecondaryAccountInstructionItem> request) {
-
-        try {
-            List<SecondaryAccountInstructionItem> validItems = validateRequest(request);
-            List<Pair<String, String>> accountUserPairs = buildAccountUserPairs(validItems);
-
-            List<SecondaryAccountInstructionItem> existingItems =
-                accountMetadataService.getBatchSecondaryAccountInstructions(accountUserPairs);
-            Set<String> existingKeys = existingItems.stream().map(SecondaryAccountsManagementApiImpl::buildCompositeKey)
-                    .collect(Collectors.toSet());
-
-            List<SecondaryAccountInstructionItem> itemsToUpdate = validItems.stream()
-                    .filter(item -> existingKeys.contains(buildCompositeKey(item)))
-                    .collect(Collectors.toList());
-
-            if (!itemsToUpdate.isEmpty()) {
-                List<SecondaryAccountInstructionItem> itemsRequiringConsentExpiry = itemsToUpdate.stream()
-                        .filter(SecondaryAccountsManagementApiImpl::isConsentExpiryRequired)
-                        .collect(Collectors.toList());
-
-                if (!itemsRequiringConsentExpiry.isEmpty()) {
-                    // TODO: Call Accelerator once with itemsRequiringConsentExpiry.
-                }
-                accountMetadataService.updateBatchSecondaryAccountInstructions(itemsToUpdate);
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("[Secondary Accounts] Updated secondary account instructions for " +
-                        itemsToUpdate.size() + " item(s)");
-            }
-
-            return Response.status(Response.Status.OK).entity(itemsToUpdate).build();
-
-        } catch (AccountMetadataException e) {
-            log.error("[Secondary Accounts] Failed to update secondary account instructions", e);
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(new ErrorResponse().errorDescription(
-                            "Failed to update secondary account instructions: " + e.getMessage()))
-                    .build();
-        }
     }
 
     /**
@@ -191,6 +144,13 @@ public class SecondaryAccountsManagementApiImpl {
             }
 
             if (!itemsToUpdate.isEmpty()) {
+                List<SecondaryAccountInstructionItem> itemsRequiringConsentExpiry = itemsToUpdate.stream()
+                        .filter(SecondaryAccountsManagementApiImpl::isConsentExpiryRequired)
+                        .collect(Collectors.toList());
+
+                if (!itemsRequiringConsentExpiry.isEmpty()) {
+                    ConsentExpiryUtil.fetchAndExpireConsents(itemsRequiringConsentExpiry);
+                }
                 accountMetadataService.updateBatchSecondaryAccountInstructions(itemsToUpdate);
             }
 

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/core/AccountMetadataService.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/core/AccountMetadataService.java
@@ -21,6 +21,7 @@ package org.wso2.openbanking.consumerdatastandards.account.metadata.service.core
 import org.apache.commons.lang3.tuple.Pair;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.exceptions.AccountMetadataException;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.BusinessStakeholderPermissionItem;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.LegalEntitySharingItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.SecondaryAccountInstructionItem;
 
 import java.util.List;
@@ -86,6 +87,26 @@ public interface AccountMetadataService {
         throws AccountMetadataException;
 
     /**
+     * Retrieve all legal entity sharing status records for multiple account-user pairs from
+     * fs_account_secondary_user_legal_entity.
+     *
+     * @param accountUserPairs list of (accountId, userId) pairs to query
+     * @return list of legal entity sharing status records
+     * @throws AccountMetadataException if an error occurs
+     */
+    List<LegalEntitySharingItem> getBatchLegalEntitySharingStatuses(
+            List<Pair<String, String>> accountUserPairs) throws AccountMetadataException;
+
+    /**
+     * Upsert legal entity sharing status records. Inserts new rows or updates
+     * LEGAL_ENTITY_STATUS when the primary key already exists.
+     *
+     * @param items legal entity sharing items to upsert
+     * @throws AccountMetadataException if an error occurs
+     */
+    void upsertBatchLegalEntitySharingStatuses(List<LegalEntitySharingItem> items) throws AccountMetadataException;
+
+    /**
      * Batch retrieve business stakeholder permissions for multiple account-user pairs.
      *
      * @param accountUserPairs list of (accountId, userId) pairs to query
@@ -131,5 +152,4 @@ public interface AccountMetadataService {
      */
     void deleteBatchBusinessStakeholderPermissions(List<BusinessStakeholderPermissionItem> permissionItems)
         throws AccountMetadataException;
-
 }

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/core/AccountMetadataServiceImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/core/AccountMetadataServiceImpl.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.exceptions.AccountMetadataException;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.BusinessStakeholderPermissionItem;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.LegalEntitySharingItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.SecondaryAccountInstructionItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.service.dao.AccountMetadataDAO;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.service.dao.AccountMetadataDAOImpl;
@@ -112,8 +113,7 @@ public class AccountMetadataServiceImpl implements AccountMetadataService {
      * @throws AccountMetadataException if an error occurs
      */
     @Override
-    public Map<String, String> getBatchDisclosureOptions(List<String> accountIds)
-            throws AccountMetadataException {
+    public Map<String, String> getBatchDisclosureOptions(List<String> accountIds) throws AccountMetadataException {
 
         try (Connection conn = connectionProvider.getConnection()) {
             return metadataDAO.getBatchDisclosureOptions(conn, accountIds);
@@ -130,8 +130,7 @@ public class AccountMetadataServiceImpl implements AccountMetadataService {
      * @throws AccountMetadataException if an error occurs
      */
     @Override
-    public void addBatchDisclosureOptions(Map<String, String> accountDisclosureMap)
-            throws AccountMetadataException {
+    public void addBatchDisclosureOptions(Map<String, String> accountDisclosureMap) throws AccountMetadataException {
 
         try (Connection conn = connectionProvider.getConnection()) {
             metadataDAO.addBatchDisclosureOptions(conn, accountDisclosureMap);
@@ -148,8 +147,7 @@ public class AccountMetadataServiceImpl implements AccountMetadataService {
      * @throws AccountMetadataException if an error occurs
      */
     @Override
-    public void updateBatchDisclosureOptions(Map<String, String> accountDisclosureMap)
-            throws AccountMetadataException {
+    public void updateBatchDisclosureOptions(Map<String, String> accountDisclosureMap) throws AccountMetadataException {
 
         try (Connection conn = connectionProvider.getConnection()) {
             metadataDAO.updateBatchDisclosureOptions(conn, accountDisclosureMap);
@@ -216,6 +214,43 @@ public class AccountMetadataServiceImpl implements AccountMetadataService {
     }
 
     /**
+     * Retrieve all legal entity sharing status records for multiple account-user pairs.
+     *
+     * @param accountUserPairs list of (accountId, userId) pairs to query
+     * @return list of legal entity sharing status records
+     * @throws AccountMetadataException if an error occurs
+     */
+    @Override
+    public List<LegalEntitySharingItem> getBatchLegalEntitySharingStatuses(List<Pair<String, String>> accountUserPairs)
+            throws AccountMetadataException {
+
+        try (Connection conn = connectionProvider.getConnection()) {
+            return metadataDAO.getBatchLegalEntitySharingStatuses(conn, accountUserPairs);
+        } catch (SQLException e) {
+            log.error("Error batch retrieving legal entity sharing statuses", e);
+            throw new AccountMetadataException("Failed to batch retrieve legal entity sharing statuses", e);
+        }
+    }
+
+    /**
+     * Upsert legal entity sharing status records.
+     *
+     * @param items legal entity sharing items to upsert
+     * @throws AccountMetadataException if an error occurs
+     */
+    @Override
+    public void upsertBatchLegalEntitySharingStatuses(List<LegalEntitySharingItem> items)
+            throws AccountMetadataException {
+
+        try (Connection conn = connectionProvider.getConnection()) {
+            metadataDAO.upsertBatchLegalEntitySharingStatuses(conn, items);
+        } catch (SQLException e) {
+            log.error("Error batch upserting legal entity sharing statuses", e);
+            throw new AccountMetadataException("Failed to batch upsert legal entity sharing statuses", e);
+        }
+    }
+
+    /**
      * Batch retrieve business stakeholder permissions for multiple account-user pairs.
      *
      * @param accountUserPairs list of (accountId, userId) pairs to query
@@ -223,7 +258,7 @@ public class AccountMetadataServiceImpl implements AccountMetadataService {
      * @throws AccountMetadataException if an error occurs
      */
     @Override
-        public List<BusinessStakeholderPermissionItem> getBatchBusinessStakeholderPermissions(
+    public List<BusinessStakeholderPermissionItem> getBatchBusinessStakeholderPermissions(
             List<Pair<String, String>> accountUserPairs) throws AccountMetadataException {
 
         try (Connection conn = connectionProvider.getConnection()) {

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/AccountMetadataDAO.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/AccountMetadataDAO.java
@@ -21,6 +21,7 @@ package org.wso2.openbanking.consumerdatastandards.account.metadata.service.dao;
 import org.apache.commons.lang3.tuple.Pair;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.exceptions.AccountMetadataException;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.BusinessStakeholderPermissionItem;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.LegalEntitySharingItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.SecondaryAccountInstructionItem;
 
 import java.sql.Connection;
@@ -96,7 +97,31 @@ public interface AccountMetadataDAO {
             throws AccountMetadataException;
 
     /**
+     * Retrieve all legal entity sharing status rows for multiple account-user pairs from
+     * fs_account_secondary_user_legal_entity.
+     *
+     * @param conn             the database connection
+     * @param accountUserPairs list of (accountId, userId) pairs to query
+     * @return list of legal entity sharing status records
+     * @throws AccountMetadataException if an error occurs
+     */
+    List<LegalEntitySharingItem> getBatchLegalEntitySharingStatuses(Connection conn,
+            List<Pair<String, String>> accountUserPairs) throws AccountMetadataException;
+
+    /**
+     * Upsert legal entity sharing status rows. Inserts a new row or updates
+     * LEGAL_ENTITY_STATUS and LAST_UPDATED_TIMESTAMP when the primary key already exists.
+     *
+     * @param conn  the database connection
+     * @param items legal entity sharing items to upsert
+     * @throws AccountMetadataException if an error occurs
+     */
+    void upsertBatchLegalEntitySharingStatuses(Connection conn, List<LegalEntitySharingItem> items)
+            throws AccountMetadataException;
+
+    /**
      * Batch retrieve business stakeholder permissions for multiple account-user pairs.
+     *
      * @param conn the database connection
      * @param accountUserPairs list of (accountId, userId) pairs to query
      * @return list of existing business stakeholder permission records
@@ -146,5 +171,4 @@ public interface AccountMetadataDAO {
      */
     void deleteBatchBusinessStakeholderPermissions(Connection conn,
             List<BusinessStakeholderPermissionItem> permissionItems) throws AccountMetadataException;
-
 }

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/AccountMetadataDAOImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/AccountMetadataDAOImpl.java
@@ -21,8 +21,10 @@ package org.wso2.openbanking.consumerdatastandards.account.metadata.service.dao;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.constants.CommonConstants;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.exceptions.AccountMetadataException;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.BusinessStakeholderPermissionItem;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.LegalEntitySharingItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.model.SecondaryAccountInstructionItem;
 import org.wso2.openbanking.consumerdatastandards.account.metadata.service.dao.queries.AccountMetadataDbQueries;
 
@@ -45,22 +47,29 @@ import java.util.Map;
 public class  AccountMetadataDAOImpl implements AccountMetadataDAO {
 
     private static final Log log = LogFactory.getLog(AccountMetadataDAOImpl.class);
+    private final AccountMetadataDbQueries dbQueries;
+
     // Column names for DOMS table.
     private static final String DISCLOSURE_OPTIONS_COLUMN_ACCOUNT_ID = "ACCOUNT_ID";
-    private static final String DISCLOSURE_OPTIONS_COLUMN_STATUS = "DISCLOSURE_OPTION_STATUS";
+    private static final String DISCLOSURE_OPTIONS_COLUMN_STATUS = "DISCLOSURE_OPTIONS_STATUS";
+
     // Column names for secondary user instructions table.
     private static final String SECONDARY_INSTRUCTIONS_COLUMN_ACCOUNT_ID = "ACCOUNT_ID";
     private static final String SECONDARY_INSTRUCTIONS_COLUMN_USER_ID = "USER_ID";
-    private static final String SECONDARY_INSTRUCTIONS_COLUMN_STATUS =
-            "INSTRUCTION_STATUS";
+    private static final String SECONDARY_INSTRUCTIONS_COLUMN_STATUS = "INSTRUCTION_STATUS";
     private static final String SECONDARY_INSTRUCTIONS_COLUMN_OTHER_ACCOUNTS_AVAILABILITY =
-        "OTHER_ACCOUNTS_AVAILABILITY";
+            "OTHER_ACCOUNTS_AVAILABILITY";
+
+    // Column names for legal entity sharing status table.
+    private static final String LEGAL_ENTITY_TABLE_COLUMN_ACCOUNT_ID = "ACCOUNT_ID";
+    private static final String LEGAL_ENTITY_TABLE_COLUMN_USER_ID = "USER_ID";
+    private static final String LEGAL_ENTITY_TABLE_COLUMN_LEGAL_ENTITY_ID = "LEGAL_ENTITY_ID";
+    private static final String LEGAL_ENTITY_TABLE_COLUMN_STATUS = "LEGAL_ENTITY_STATUS";
+
     // Column names for business stakeholder permissions table.
     private static final String BNR_PERMISSIONS_COLUMN_ACCOUNT_ID = "ACCOUNT_ID";
     private static final String BNR_PERMISSIONS_COLUMN_USER_ID = "USER_ID";
     private static final String BNR_PERMISSIONS_COLUMN_PERMISSION = "PERMISSION";
-
-    private final AccountMetadataDbQueries dbQueries;
 
     /**
      * Constructs a new DAO with the specified query provider.
@@ -300,12 +309,94 @@ public class  AccountMetadataDAOImpl implements AccountMetadataDAO {
      * {@inheritDoc}
      */
     @Override
-        public List<BusinessStakeholderPermissionItem> getBatchBusinessStakeholderPermissions(Connection conn,
+    public List<LegalEntitySharingItem> getBatchLegalEntitySharingStatuses(Connection conn,
             List<Pair<String, String>> accountUserPairs) throws AccountMetadataException {
 
         if (accountUserPairs == null || accountUserPairs.isEmpty()) {
-            throw new AccountMetadataException("Account-user pair list cannot be null or empty " +
-                    "when retrieving business stakeholder permissions");
+            return Collections.emptyList();
+        }
+
+        String sql = dbQueries.getBatchGetLegalEntitySharingStatusesQuery(accountUserPairs.size());
+        List<LegalEntitySharingItem> result = new ArrayList<>();
+
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            int parameterIndex = 1;
+            for (Pair<String, String> pair : accountUserPairs) {
+                stmt.setString(parameterIndex++, pair.getLeft());
+                stmt.setString(parameterIndex++, pair.getRight());
+            }
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    String statusStr = rs.getString(LEGAL_ENTITY_TABLE_COLUMN_STATUS);
+                    LegalEntitySharingItem item = new LegalEntitySharingItem();
+                    item.setAccountID(rs.getString(LEGAL_ENTITY_TABLE_COLUMN_ACCOUNT_ID));
+                    item.setSecondaryUserID(rs.getString(LEGAL_ENTITY_TABLE_COLUMN_USER_ID));
+                    item.setLegalEntityID(rs.getString(LEGAL_ENTITY_TABLE_COLUMN_LEGAL_ENTITY_ID));
+                    item.setLegalEntitySharingStatus(
+                            CommonConstants.LEGAL_ENTITY_SHARING_STATUS_BLOCKED.equalsIgnoreCase(statusStr)
+                                    ? LegalEntitySharingItem.LegalEntitySharingStatusEnum.blocked
+                                    : LegalEntitySharingItem.LegalEntitySharingStatusEnum.active);
+                    result.add(item);
+                }
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Retrieved " + result.size() + " legal entity sharing status rows.");
+            }
+            return result;
+
+        } catch (SQLException e) {
+            log.error("Error retrieving batch legal entity sharing statuses", e);
+            throw new AccountMetadataException("Failed to retrieve batch legal entity sharing statuses", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void upsertBatchLegalEntitySharingStatuses(Connection conn, List<LegalEntitySharingItem> items)
+            throws AccountMetadataException {
+
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        String sql = dbQueries.getUpsertLegalEntitySharingStatusQuery();
+
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            Timestamp currentTimestamp = new Timestamp((new Date()).getTime());
+
+            for (LegalEntitySharingItem item : items) {
+                stmt.setString(1, item.getAccountID());
+                stmt.setString(2, item.getSecondaryUserID());
+                stmt.setString(3, item.getLegalEntityID());
+                stmt.setString(4, item.getLegalEntitySharingStatus().toString());
+                stmt.setTimestamp(5, currentTimestamp);
+                stmt.addBatch();
+            }
+
+            int[] results = stmt.executeBatch();
+            if (log.isDebugEnabled()) {
+                log.debug("Batch upserted " + results.length + " legal entity sharing status rows.");
+            }
+
+        } catch (SQLException e) {
+            log.error("Error batch upserting legal entity sharing statuses", e);
+            throw new AccountMetadataException("Failed to batch upsert legal entity sharing statuses", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+        public List<BusinessStakeholderPermissionItem> getBatchBusinessStakeholderPermissions(Connection conn,
+            List<Pair<String, String>> accountUserPairs) throws AccountMetadataException {
+
+        if (accountUserPairs == null) {
+            return Collections.emptyList();
         }
 
         String sql = dbQueries.getBatchGetBusinessStakeholderPermissionQuery(accountUserPairs);
@@ -391,8 +482,7 @@ public class  AccountMetadataDAOImpl implements AccountMetadataDAO {
             List<BusinessStakeholderPermissionItem> permissionItems) throws AccountMetadataException {
 
         if (permissionItems == null || permissionItems.isEmpty()) {
-            throw new AccountMetadataException("Permission items cannot be null or empty " +
-                        "when adding business stakeholder permissions");
+            return;
         }
 
         String sql = dbQueries.getBatchAddBusinessStakeholderPermissionQuery();

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/queries/AccountMetadataDbQueries.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/queries/AccountMetadataDbQueries.java
@@ -75,6 +75,25 @@ public interface AccountMetadataDbQueries {
      */
     String getBatchUpdateSecondaryAccountInstructionQuery();
 
+    // DB Queries related to Legal Entity Sharing Feature.
+    /**
+     * Get the SQL query for retrieving all legal entity sharing status rows for multiple account-user pairs
+     * from the fs_account_secondary_user_legal_entity table.
+     *
+     * @param pairCount number of account-user pairs to query
+     * @return the SQL query with placeholders
+     */
+    String getBatchGetLegalEntitySharingStatusesQuery(int pairCount);
+
+    /**
+     * Get the SQL upsert query for inserting or updating a legal entity sharing status row.
+     * On duplicate key (ACCOUNT_ID, USER_ID, LEGAL_ENTITY_ID), only LEGAL_ENTITY_STATUS and
+     * LAST_UPDATED_TIMESTAMP are updated.
+     *
+     * @return the SQL upsert query
+     */
+    String getUpsertLegalEntitySharingStatusQuery();
+
     // DB Queries related to BNR Feature.
     /**
      * Get the SQL query for retrieving business stakeholder permission records for

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/queries/AccountMetadataDbQueriesMySqlImpl.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/service/dao/queries/AccountMetadataDbQueriesMySqlImpl.java
@@ -33,7 +33,7 @@ public class AccountMetadataDbQueriesMySqlImpl implements AccountMetadataDbQueri
     @Override
     public String getBatchGetDisclosureOptionQuery(int accountCount) {
         StringBuilder query = new StringBuilder(
-                "SELECT ACCOUNT_ID, DISCLOSURE_OPTION_STATUS FROM fs_account_doms_status WHERE ACCOUNT_ID IN (");
+                "SELECT ACCOUNT_ID, DISCLOSURE_OPTIONS_STATUS FROM fs_account_doms_status WHERE ACCOUNT_ID IN (");
         for (int i = 0; i < accountCount; i++) {
             query.append("?");
             if (i < accountCount - 1) {
@@ -49,7 +49,7 @@ public class AccountMetadataDbQueriesMySqlImpl implements AccountMetadataDbQueri
      */
     @Override
     public String getBatchAddDisclosureOptionQuery() {
-        return "INSERT INTO fs_account_doms_status (ACCOUNT_ID, DISCLOSURE_OPTION_STATUS, LAST_UPDATED_TIMESTAMP) " +
+        return "INSERT INTO fs_account_doms_status (ACCOUNT_ID, DISCLOSURE_OPTIONS_STATUS, LAST_UPDATED_TIMESTAMP) " +
                 "VALUES (?, ?, ?)";
     }
 
@@ -58,7 +58,7 @@ public class AccountMetadataDbQueriesMySqlImpl implements AccountMetadataDbQueri
      */
     @Override
     public String getBatchUpdateDisclosureOptionQuery() {
-        return "UPDATE fs_account_doms_status SET DISCLOSURE_OPTION_STATUS = ?, " +
+        return "UPDATE fs_account_doms_status SET DISCLOSURE_OPTIONS_STATUS = ?, " +
                 "LAST_UPDATED_TIMESTAMP = ? WHERE ACCOUNT_ID = ?";
     }
 
@@ -96,6 +96,36 @@ public class AccountMetadataDbQueriesMySqlImpl implements AccountMetadataDbQueri
     public String getBatchUpdateSecondaryAccountInstructionQuery() {
         return "UPDATE fs_account_secondary_user SET INSTRUCTION_STATUS = ?, " +
                 "OTHER_ACCOUNTS_AVAILABILITY = ?, LAST_UPDATED_TIMESTAMP = ? WHERE ACCOUNT_ID = ? AND USER_ID = ?";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getBatchGetLegalEntitySharingStatusesQuery(int pairCount) {
+        StringBuilder query = new StringBuilder(
+                "SELECT ACCOUNT_ID, USER_ID, LEGAL_ENTITY_ID, LEGAL_ENTITY_STATUS " +
+                        "FROM fs_account_secondary_user_legal_entity WHERE (ACCOUNT_ID, USER_ID) IN (");
+        for (int i = 0; i < pairCount; i++) {
+            query.append("(?,?)");
+            if (i < pairCount - 1) {
+                query.append(",");
+            }
+        }
+        query.append(")");
+        return query.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getUpsertLegalEntitySharingStatusQuery() {
+        return "INSERT INTO fs_account_secondary_user_legal_entity " +
+                "(ACCOUNT_ID, USER_ID, LEGAL_ENTITY_ID, LEGAL_ENTITY_STATUS, LAST_UPDATED_TIMESTAMP) " +
+                "VALUES (?, ?, ?, ?, ?) " +
+                "ON DUPLICATE KEY UPDATE LEGAL_ENTITY_STATUS = VALUES(LEGAL_ENTITY_STATUS), " +
+                "LAST_UPDATED_TIMESTAMP = VALUES(LAST_UPDATED_TIMESTAMP)";
     }
 
     /**

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/utils/ConsentExpiryUtil.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/utils/ConsentExpiryUtil.java
@@ -1,0 +1,367 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.openbanking.consumerdatastandards.account.metadata.utils;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.configurations.ConfigurableProperties;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.constants.CommonConstants;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.exceptions.AccountMetadataException;
+import org.wso2.openbanking.consumerdatastandards.account.metadata.model.SecondaryAccountInstructionItem;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Utility class for fetching access tokens and consent IDs from the WSO2 Accelerator,
+ * used during secondary account consent expiry processing.
+ *
+ * <p>NOTE: This class uses a trust-all SSL context suitable for development environments only.
+ * Replace {@code TrustAllStrategy} with a proper trust store before deploying to production.
+ */
+public class ConsentExpiryUtil {
+
+    private static final Log log = LogFactory.getLog(ConsentExpiryUtil.class);
+
+    /**
+     * Functional interface for HTTP client creation; package-private for test substitution.
+     */
+    interface HttpClientSupplier {
+        CloseableHttpClient get() throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException;
+    }
+
+    // Package-private: replaced in unit tests via reflection to inject a mock client.
+    static HttpClientSupplier httpClientSupplier = ConsentExpiryUtil::buildSSlClient;
+
+    private ConsentExpiryUtil() {
+        // Prevent instantiation — all methods are static.
+    }
+
+    /**
+     * Fetches all consents for the secondary users in the given items list and immediately
+     * expires each one. Convenience wrapper around {@link #fetchConsentIdsForUsers} and
+     * {@link #expireConsents}.
+     *
+     * @param items list of secondary account instruction items requiring consent expiry
+     * @throws AccountMetadataException if the access token cannot be obtained or any consent
+     *                                  expiry call fails
+     */
+    public static void fetchAndExpireConsents(List<SecondaryAccountInstructionItem> items)
+            throws AccountMetadataException {
+
+        Map<String, String> consentClientMap = fetchConsentIdsForUsers(items);
+        if (log.isDebugEnabled()) {
+            log.debug("[ConsentExpiry] Fetched " + consentClientMap.size()
+                    + " consent(s) to expire");
+        }
+        expireConsents(consentClientMap);
+    }
+
+    /**
+     * Orchestrates consent retrieval for all unique secondary users in the given items list.
+     * Fetches one access token and reuses it across all user queries.
+     *
+     * @param items list of secondary account instruction items requiring consent expiry
+     * @return map of consentId to clientId for all consents found
+     * @throws AccountMetadataException if the access token cannot be obtained
+     */
+    public static Map<String, String> fetchConsentIdsForUsers(
+            List<SecondaryAccountInstructionItem> items) throws AccountMetadataException {
+
+        List<String> uniqueUserIds = items.stream()
+                .map(SecondaryAccountInstructionItem::getSecondaryUserId)
+                .filter(id -> id != null && !id.trim().isEmpty())
+                .distinct()
+                .collect(Collectors.toList());
+
+        String accessToken = fetchAccessToken();
+
+        Map<String, String> consentClientMap = new LinkedHashMap<>();
+        for (String userId : uniqueUserIds) {
+            Map<String, String> userConsents = fetchConsentIdsForUser(userId, accessToken);
+            consentClientMap.putAll(userConsents);
+            if (log.isDebugEnabled()) {
+                log.debug("[ConsentExpiry] Found " + userConsents.size() + " consent(s) for userId=" + userId);
+            }
+        }
+        return consentClientMap;
+    }
+
+    /**
+     * Fetches an OAuth2 access token from the Accelerator token endpoint using the password grant.
+     *
+     * @return access token string
+     * @throws AccountMetadataException if the token endpoint returns a non-200 response or
+     *                                  the request fails
+     */
+    public static String fetchAccessToken() throws AccountMetadataException {
+
+        String credentials = ConfigurableProperties.ACCOUNT_METADATA_CLIENT_APP_ID + ":"
+                + ConfigurableProperties.ACCOUNT_METADATA_CLIENT_APP_SECRET;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+
+        try (CloseableHttpClient client = httpClientSupplier.get()) {
+
+            HttpPost request = new HttpPost(ConfigurableProperties.ACCELERATOR_TOKEN_ENDPOINT_URL);
+            request.setHeader(CommonConstants.AUTHORIZATION_HEADER,
+                    CommonConstants.BASIC_PREFIX + encodedCredentials);
+            request.setHeader(CommonConstants.CONTENT_TYPE_HEADER, CommonConstants.CONTENT_TYPE_FORM);
+
+            List<NameValuePair> params = new ArrayList<>();
+            params.add(new BasicNameValuePair(CommonConstants.PARAM_GRANT_TYPE, CommonConstants.GRANT_TYPE_PASSWORD));
+            params.add(new BasicNameValuePair(
+                    CommonConstants.PARAM_USERNAME, ConfigurableProperties.CUSTOMER_CARE_OFFICER_USERNAME));
+            params.add(new BasicNameValuePair(
+                    CommonConstants.PARAM_PASSWORD, ConfigurableProperties.CUSTOMER_CARE_OFFICER_PASSWORD));
+            params.add(new BasicNameValuePair(
+                    CommonConstants.PARAM_SCOPE, ConfigurableProperties.CUSTOMER_CARE_OFFICER_TOKEN_SCOPE));
+            request.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+
+            HttpResponse response = client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode != HttpURLConnection.HTTP_OK) {
+                throw new AccountMetadataException(
+                        "[ConsentExpiry] Failed to obtain access token. HTTP status: " + statusCode);
+            }
+
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            JsonObject jsonObject = JsonParser.parseString(body).getAsJsonObject();
+            return jsonObject.get(CommonConstants.TOKEN_RESPONSE_ACCESS_TOKEN).getAsString();
+
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException 
+                 | KeyManagementException | JsonSyntaxException e) {
+            throw new AccountMetadataException(
+                    "[ConsentExpiry] Exception while fetching access token: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Fetches consents for a specific user from the Accelerator consent search API.
+     *
+     * @param userId      secondary user ID to search consents for
+     * @param accessToken Bearer token obtained from {@link #fetchAccessToken()}
+     * @return map of consentId to clientId
+     * @throws AccountMetadataException if the consent search returns a non-200 response or
+     *                                  the request fails
+     */
+    public static Map<String, String> fetchConsentIdsForUser(String userId, String accessToken)
+            throws AccountMetadataException {
+
+        if (StringUtils.isBlank(userId) || StringUtils.isBlank(accessToken)) {
+            throw new AccountMetadataException(
+                    "[ConsentExpiry] userId or accessToken is blank; cannot search consents");
+        }
+
+        try (CloseableHttpClient client = httpClientSupplier.get()) {
+
+            HttpGet request = getConsentSearchAPIRequest(userId, accessToken);
+
+            HttpResponse response = client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode != HttpURLConnection.HTTP_OK) {
+                throw new AccountMetadataException(
+                        "[ConsentExpiry] Consent search failed for userId=" + userId
+                                + ". HTTP status: " + statusCode);
+            }
+
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            return extractConsentClientMap(body, userId);
+
+        } catch (IOException | URISyntaxException | KeyStoreException
+                 | NoSuchAlgorithmException | KeyManagementException e) {
+            throw new AccountMetadataException(
+                    "[ConsentExpiry] Exception during consent search for userId=" + userId + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static HttpGet getConsentSearchAPIRequest(String userId, String accessToken) throws URISyntaxException {
+        URIBuilder uriBuilder = new URIBuilder(ConfigurableProperties.ACCELERATOR_CONSENT_SEARCH_URL);
+        uriBuilder.addParameter(CommonConstants.CONSENT_SEARCH_PARAM_CONSENT_TYPES,
+                CommonConstants.CONSENT_TYPE_ACCOUNTS);
+        uriBuilder.addParameter(CommonConstants.CONSENT_SEARCH_PARAM_USER_IDS, userId);
+
+        HttpGet request = new HttpGet(uriBuilder.build());
+        request.setHeader(CommonConstants.AUTHORIZATION_HEADER,
+                CommonConstants.BEARER_PREFIX + accessToken);
+        request.setHeader(CommonConstants.ACCEPT_HEADER, CommonConstants.CONTENT_TYPE_JSON);
+        return request;
+    }
+
+    /**
+     * Expires all consents in the provided map by invoking the Accelerator consent update API.
+     * Uses Basic Auth with admin credentials and sends a minimal body containing only the
+     * "Expired" status. The clientId associated with each consent is sent as the
+     * {@code x-wso2-client-id} request header.
+     * Attempts every consent before throwing so that partial progress is maximised.
+     *
+     * @param consentClientMap map of consentId to clientId for all consents to expire
+     * @throws AccountMetadataException if one or more consent expiry calls fail
+     */
+    public static void expireConsents(Map<String, String> consentClientMap)
+            throws AccountMetadataException {
+
+        String credentials = ConfigurableProperties.IS_ADMIN_USERNAME + ":"
+                + ConfigurableProperties.IS_ADMIN_PASSWORD;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+
+        for (Map.Entry<String, String> entry : consentClientMap.entrySet()) {
+            String consentId = entry.getKey();
+            String clientId = entry.getValue();
+            expireSingleConsent(consentId, clientId, encodedCredentials);
+            if (log.isDebugEnabled()) {
+                log.debug("[ConsentExpiry] Expired consentId=" + consentId + " clientId=" + clientId);
+            }
+        }
+    }
+
+    /**
+     * Sends a PUT request to expire a single consent.
+     *
+     * @param consentId          the consent ID to expire
+     * @param clientId           the client ID associated with the consent, sent as x-wso2-client-id
+     * @param encodedCredentials Base64-encoded admin credentials for Basic Auth
+     * @throws AccountMetadataException if the consent update returns a non-200 response or
+     *                                  the request fails
+     */
+    private static void expireSingleConsent(String consentId, String clientId, String encodedCredentials)
+            throws AccountMetadataException {
+
+        try (CloseableHttpClient client = httpClientSupplier.get()) {
+
+            String url = ConfigurableProperties.ACCELERATOR_CONSENT_UPDATE_BASE_URL + "/" + consentId;
+
+            HttpPut request = new HttpPut(url);
+
+            request.setHeader(CommonConstants.AUTHORIZATION_HEADER,
+                    CommonConstants.BASIC_PREFIX + encodedCredentials);
+            request.setHeader(CommonConstants.CONTENT_TYPE_HEADER, CommonConstants.CONTENT_TYPE_JSON);
+            request.setHeader(CommonConstants.HEADER_WSO2_CLIENT_ID, clientId);
+            request.setHeader(CommonConstants.HEADER_WSO2_INTERNAL_REQUEST,
+                    CommonConstants.WSO2_INTERNAL_REQUEST_VALUE);
+            request.setHeader(CommonConstants.HEADER_FAPI_INTERACTION_ID, UUID.randomUUID().toString());
+
+            JsonObject body = new JsonObject();
+            body.addProperty(CommonConstants.CONSENT_UPDATE_STATUS, CommonConstants.CONSENT_EXPIRE_STATUS);
+
+            request.setEntity(new StringEntity(body.toString(), StandardCharsets.UTF_8));
+
+            HttpResponse response = client.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode != HttpURLConnection.HTTP_OK) {
+                throw new AccountMetadataException("[ConsentExpiry] Failed to expire consentId=" + consentId
+                        + ". HTTP status: " + statusCode);
+            }
+
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | KeyManagementException e) {
+            throw new AccountMetadataException(
+                    "[ConsentExpiry] Exception while expiring consentId=" + consentId + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Builds an HTTPS client that trusts all SSL certificates.
+     * IMPORTANT: Replace TrustAllStrategy with a production trust store before going live.
+     */
+    static CloseableHttpClient buildSSlClient()
+            throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(ConfigurableProperties.ACCELERATOR_CONNECT_TIMEOUT_MILLIS)
+                .setSocketTimeout(ConfigurableProperties.ACCELERATOR_SOCKET_TIMEOUT_MILLIS)
+                .build();
+
+        SSLContext sslContext = SSLContextBuilder.create().loadTrustMaterial(TrustAllStrategy.INSTANCE).build();
+
+        SSLConnectionSocketFactory sslSocketFactory =
+                new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+
+        return HttpClients.custom().setDefaultRequestConfig(requestConfig).setSSLSocketFactory(sslSocketFactory)
+                .build();
+    }
+
+    /**
+     * Extracts a consentId-to-clientId map from the consent search response JSON.
+     * Supports both a plain JSON array {@code [ { "consentId": "...", "clientId": "..." }, ... ]}
+     * and a wrapped shape {@code { "data": [ ... ] }}.
+     */
+    private static Map<String, String> extractConsentClientMap(String responseBody, String userId)
+            throws AccountMetadataException {
+
+        Map<String, String> consentClientMap = new LinkedHashMap<>();
+        try {
+            JsonElement root = JsonParser.parseString(responseBody);
+            JsonArray consentsArray;
+            JsonElement dataEl = root.getAsJsonObject().get(CommonConstants.CONSENT_RESPONSE_DATA);
+            consentsArray = dataEl.getAsJsonArray();
+
+            for (JsonElement item : consentsArray) {
+                JsonObject obj = item.getAsJsonObject();
+                JsonElement idEl = obj.get(CommonConstants.CONSENT_RESPONSE_CONSENT_ID);
+                JsonElement clientEl = obj.get(CommonConstants.CONSENT_RESPONSE_CLIENT_ID);
+                String clientId = (clientEl != null && !clientEl.isJsonNull()) ? clientEl.getAsString() : "";
+                consentClientMap.put(idEl.getAsString(), clientId);
+            }
+
+        } catch (JsonSyntaxException | IllegalStateException | NullPointerException e) {
+            throw new AccountMetadataException(
+                    "[ConsentExpiry] Failed to parse consent search response for userId=" + userId, e);
+        }
+        return consentClientMap;
+    }
+}

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/utils/ConsentExpiryUtil.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/utils/ConsentExpiryUtil.java
@@ -322,8 +322,8 @@ public class ConsentExpiryUtil {
             throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
 
         RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(ConfigurableProperties.ACCELERATOR_CONNECT_TIMEOUT_MILLIS)
-                .setSocketTimeout(ConfigurableProperties.ACCELERATOR_SOCKET_TIMEOUT_MILLIS)
+                .setConnectTimeout(ConfigurableProperties.CONNECT_TIMEOUT_MILLIS)
+                .setSocketTimeout(ConfigurableProperties.SOCKET_TIMEOUT_MILLIS)
                 .build();
 
         SSLContext sslContext = SSLContextBuilder.create().loadTrustMaterial(TrustAllStrategy.INSTANCE).build();

--- a/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/utils/DatabaseUtil.java
+++ b/components/account-metadata-service/src/main/java/org/wso2/openbanking/consumerdatastandards/account/metadata/utils/DatabaseUtil.java
@@ -60,6 +60,12 @@ public class DatabaseUtil {
         }
     }
 
+    /**
+     * Obtain a connection from the configured Account Metadata datasource.
+     *
+     * @return a live database connection
+     * @throws SQLException if a connection cannot be created
+     */
     public static Connection getConnection() throws SQLException {
         return dataSource.getConnection();
     }

--- a/components/account-metadata-service/src/main/resources/account-meta-data.yaml
+++ b/components/account-metadata-service/src/main/resources/account-meta-data.yaml
@@ -211,45 +211,6 @@ paths:
         - OAuth2: []
         - BasicAuth: []
 
-    put:
-      tags:
-        - Secondary User Instruction
-      summary: Update secondary accounts instruction status for one or more accounts
-      description: This API is used to update the CDS Secondary Accounts Instruction and Privilege Status.
-      operationId: updateSecondaryAccountStatusPut
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/SecondaryAccountInstructionItem'
-      responses:
-        '200':
-          description: Secondary accounts instruction status successfully updated
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SecondaryAccountInstructionItem'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      security:
-        - OAuth2: []
-        - BasicAuth: []
-
   /business-stakeholders:
     get:
       tags:
@@ -417,6 +378,105 @@ paths:
         - OAuth2: []
         - BasicAuth: []
 
+  /legal-entity:
+    get:
+      tags:
+        - CeasingSecondaryUserShare
+      summary: Get legal entity sharing statuses for one user across multiple accounts
+      description: Retrieve legal entity sharing statuses (blocked or active) for a given user ID and multiple account IDs (comma-separated).
+      operationId: getLegalEntitySharingStatusGet
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          description: User ID
+          schema:
+            type: string
+            minLength: 1
+            example: secondary.user@example.com
+        - name: accountIds
+          in: query
+          required: true
+          description: Comma-separated account IDs
+          schema:
+            type: string
+            minLength: 1
+            example: "acc-12345,acc-67890"
+        - name: clientId
+          in: query
+          required: false
+          description: Software product client ID used to resolve the legal entity ID from the IS server. When provided, only records matching the resolved legal entity are returned.
+          schema:
+            type: string
+            example: "client-001"
+      responses:
+        '200':
+          description: Legal entity sharing statuses retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalEntitySharingItem'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - OAuth2: []
+        - BasicAuth: []
+
+    put:
+      tags:
+        - CeasingSecondaryUserShare
+      summary: Update legal entity sharing statuses for one or more records
+      description: |
+        Update legal entity sharing status records identified by the (secondaryUserID, accountID) pair.
+        If legalEntitySharingStatus is blocked, legalEntityID is added to the fs_secondary_user.BLOCKED_ENTITIES column.
+        If a record already exists, legalEntityID values are appended with a preceding ','.
+        If legalEntitySharingStatus is active, legalEntityID is removed from the BLOCKED_ENTITIES string.
+      operationId: updateLegalEntitySharingStatusPost
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/LegalEntitySharingItem'
+      responses:
+        '200':
+          description: Legal entity sharing statuses updated successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LegalEntitySharingItem'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - OAuth2: []
+        - BasicAuth: []
+
 components:
   securitySchemes:
     BasicAuth:
@@ -439,7 +499,6 @@ components:
         accountId:
           type: string
           description: Account ID
-          example: 143-000-B1234
         disclosureOption:
           type: string
           description: Disclosure option status
@@ -477,6 +536,7 @@ components:
           type: string
           description: Secondary account instruction status
           enum: [active, inactive]
+          x-enum-varnames: [active, inactive]
           example: inactive
           x-enum-description: |
             Allowed values:
@@ -588,4 +648,37 @@ components:
             minLength: 1
           example:
             - psu@gold.com@carbon.super
-            
+
+    LegalEntitySharingItem:
+      type: object
+      required:
+        - secondaryUserID
+        - accountID
+        - legalEntityID
+        - legalEntitySharingStatus
+      properties:
+        secondaryUserID:
+          type: string
+          minLength: 1
+          description: Secondary user identifier. Together with accountID, this uniquely identifies a record in fs_secondary_user.
+          example: secondary.user@example.com
+        accountID:
+          type: string
+          minLength: 1
+          description: Account ID
+          example: acc-12345
+        legalEntityID:
+          type: string
+          minLength: 1
+          description: Legal entity identifier
+          example: le-001
+        legalEntitySharingStatus:
+          type: string
+          description: Legal entity sharing status. blocked adds legalEntityID to BLOCKED_ENTITIES, active removes legalEntityID from BLOCKED_ENTITIES.
+          enum: [blocked, active]
+          x-enum-varnames: [blocked, active]
+          example: active
+          x-enum-description: |
+            Allowed values:
+              - active: Legal entity is not blocked
+              - blocked: Legal Entity is blocked

--- a/components/account-metadata-service/src/main/webapp/WEB-INF/web.xml
+++ b/components/account-metadata-service/src/main/webapp/WEB-INF/web.xml
@@ -71,7 +71,8 @@
       <param-value>
         org.wso2.openbanking.consumerdatastandards.account.metadata.api.DisclosureOptionsApi,
         org.wso2.openbanking.consumerdatastandards.account.metadata.api.SecondaryAccountsApi,
-        org.wso2.openbanking.consumerdatastandards.account.metadata.api.BusinessStakeholdersApi
+        org.wso2.openbanking.consumerdatastandards.account.metadata.api.BusinessStakeholdersApi,
+        org.wso2.openbanking.consumerdatastandards.account.metadata.api.CeasingSecondaryUserSharing
       </param-value>
     </init-param>
 


### PR DESCRIPTION
## Implement Ceasing secondary user sharing feature support for CDS Toolkit 2.0

> This pull request implements the Ceasing Secondary User Sharing feature for CDS Toolkit 2.0, in accordance with CDS standards. The implementation enables blocking at the legal entity level, ensuring that all TPPs associated with a blocked legal entity are prevented from accessing shared data. This enforces compliant cessation of data sharing by restricting consent authorization, API access, and data disclosure for all underlying TPPs, while maintaining consistent access control across the system based on the legal entity’s sharing status.

**Issue link:** *required*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [ ] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).