### PR TITLE
Add CDS Policy to Filter Ceasing secondary user sharing blocked Accounts from Account Resource call

### DIFF
--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediator.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.mediators.AbstractMediator;
 import org.json.JSONArray;
@@ -80,6 +81,7 @@ public class CDSAccountValidationMediator extends AbstractMediator {
             // Unsigned payload
             JSONObject payload = new JSONObject(accountHeaderJwt);
             String userId = null;
+            String clientId = getClientIdFromPayload(payload);
 
             // Collect authorization IDs that should be removed from validation and mapping.
             Set<String> excludedAuthIds = new HashSet<>();
@@ -132,7 +134,7 @@ public class CDSAccountValidationMediator extends AbstractMediator {
             }
 
             Set<String> blockedAccounts = CDSAccountValidationUtils.fetchAllBlockedAccounts(accountIds,
-                    this.webappBaseURL, userId, this.basicAuthCredentials);
+                    this.webappBaseURL, userId, this.basicAuthCredentials, clientId);
 
             JSONArray filteredConsentMappings = new JSONArray();
 
@@ -160,6 +162,77 @@ public class CDSAccountValidationMediator extends AbstractMediator {
 
             payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, filteredConsentMappings);
 
+            // Single-account validation: check if the requested accountId is in the allowed list
+            String electedResource = (String) messageContext.getProperty(
+                    CDSAccountValidationConstants.API_ELECTED_RESOURCE);
+            String fullRequestPath = (String) messageContext.getProperty(
+                    CDSAccountValidationConstants.REST_FULL_REQUEST_PATH);
+
+            if (electedResource != null && electedResource.contains(
+                    CDSAccountValidationConstants.API_ELECTED_RESOURCE_ACCOUNT_ID_PARAMETER)
+                    && fullRequestPath != null) {
+                String requestedAccountId = null;
+                String[] segments = fullRequestPath.split("/");
+                for (int i = 0; i < segments.length - 1; i++) {
+                    if (CDSAccountValidationConstants.RESOURCE_ACCOUNTS_TAG.equals(segments[i])) {
+                        requestedAccountId = segments[i + 1];
+                        break;
+                    }
+                }
+
+                if (requestedAccountId != null) {
+                    if (blockedAccounts.contains(requestedAccountId)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[CDS-policy] Single-account request for blocked or unknown accountId: "
+                                    + requestedAccountId);
+                        }
+                        setErrorResponseProperties(messageContext,
+                                CDSAccountValidationConstants.RESOURCE_INVALID_BANKING_ACCOUNT,
+                                CDSAccountValidationConstants.INVALID_BANKING_ACCOUNT_TITLE,
+                                CDSAccountValidationConstants.INVALID_BANKING_ACCOUNT_DESC,
+                                CDSAccountValidationConstants.HTTP_SC_404);
+                        throw new SynapseException("Account " + requestedAccountId
+                                + " is not available for data sharing");
+                    }
+                }
+            }
+
+            // POST multi-account validation: all requested accountIds must be in the allowed list
+            String httpMethod = (String) messageContext.getProperty(CDSAccountValidationConstants.REST_METHOD);
+            if (CDSAccountValidationConstants.POST_METHOD.equals(httpMethod)) {
+                String requestBody = (String) messageContext.getProperty(
+                        CDSAccountValidationConstants.ORIGINAL_REQUEST_JSON_BODY);
+                if (requestBody != null) {
+                    JSONObject requestBodyJson = new JSONObject(requestBody);
+                    if (requestBodyJson.has(CDSAccountValidationConstants.DATA_TAG)) {
+                        JSONObject dataObj = requestBodyJson.getJSONObject(
+                                CDSAccountValidationConstants.DATA_TAG);
+                        if (dataObj.has(CDSAccountValidationConstants.POST_PAYLOAD_ACCOUNT_IDS_TAG)) {
+                            JSONArray requestedAccountIds = dataObj.getJSONArray(
+                                    CDSAccountValidationConstants.POST_PAYLOAD_ACCOUNT_IDS_TAG);
+
+                            // All-or-nothing: reject if any requested account is not allowed
+                            for (int i = 0; i < requestedAccountIds.length(); i++) {
+                                String requestedAccountId = requestedAccountIds.optString(i);
+                                if (blockedAccounts.contains(requestedAccountId)) {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("[CDS-policy] POST request contains blocked or " +
+                                                "unknown accountId: " + requestedAccountId);
+                                    }
+                                    setErrorResponseProperties(messageContext,
+                                            CDSAccountValidationConstants.RESOURCE_INVALID_BANKING_ACCOUNT,
+                                            CDSAccountValidationConstants.INVALID_BANKING_ACCOUNT_TITLE,
+                                            CDSAccountValidationConstants.INVALID_BANKING_ACCOUNT_POST_DESC,
+                                            CDSAccountValidationConstants.HTTP_SC_422);
+                                    throw new SynapseException("Account " + requestedAccountId
+                                            + " is not available for data sharing");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             String signedJwt = CDSAccountValidationUtils.generateJWT(payload.toString());
             headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, signedJwt);
 
@@ -168,26 +241,34 @@ public class CDSAccountValidationMediator extends AbstractMediator {
         } catch (ParseException | JOSEException | JSONException | CDSAccountValidationException e) {
             String errorDescription = "Error during CDS mediation policy";
             log.error(errorDescription, e);
-            setErrorResponseProperties(messageContext, errorDescription);
+            setErrorResponseProperties(messageContext, "Internal Server Error", "CDS DOMS Policy Error",
+                    errorDescription, "500");
+            throw new SynapseException(errorDescription, e);
         }
 
         return true;
     }
 
     /**
-     * Sets standardized error response properties in the message context when CDS mediation fails.
+     * Sets error response properties in the message context.
      *
      * @param messageContext Synapse message context used to propagate error details
-     * @param errorDescription description of the error encountered during mediation
+     * @param errorCode error code value
+     * @param errorTitle error title
+     * @param errorDescription error description
+     * @param httpStatusCode HTTP status code as string
      */
     @Generated(message = "No testable logic")
     private static void setErrorResponseProperties(MessageContext messageContext,
-                                                   String errorDescription) {
+                                                   String errorCode,
+                                                   String errorTitle,
+                                                   String errorDescription,
+                                                   String httpStatusCode) {
 
-        messageContext.setProperty(CDSAccountValidationConstants.ERROR_CODE, "Internal Server Error");
-        messageContext.setProperty(CDSAccountValidationConstants.ERROR_TITLE, "CDS DOMS Policy Error");
+        messageContext.setProperty(CDSAccountValidationConstants.ERROR_CODE, errorCode);
+        messageContext.setProperty(CDSAccountValidationConstants.ERROR_TITLE, errorTitle);
         messageContext.setProperty(CDSAccountValidationConstants.ERROR_DESCRIPTION, errorDescription);
-        messageContext.setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC, "500");
+        messageContext.setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC, httpStatusCode);
     }
 
     /**
@@ -221,5 +302,15 @@ public class CDSAccountValidationMediator extends AbstractMediator {
     private static boolean isExcludedAuthType(String authType) {
         return CDSAccountValidationConstants.LINKED_MEMBER_TAG.equalsIgnoreCase(authType)
                 || isSecondaryAccountOwnerAuthType(authType) || isBusinessAccountAuthType(authType);
+    }
+
+    /**
+     * Extract client id from payload using either clientId or client_id.
+     *
+     * @param payload account-request-information payload
+     * @return client id value if present, otherwise empty string
+     */
+    private static String getClientIdFromPayload(JSONObject payload) {
+            return payload.optString(CDSAccountValidationConstants.CLIENT_ID_TAG);
     }
 }

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/constants/CDSAccountValidationConstants.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/constants/CDSAccountValidationConstants.java
@@ -37,6 +37,8 @@ public class CDSAccountValidationConstants {
 
     // Additional param keys
     public static final String USER_ID_TAG = "userId";
+    public static final String CLIENT_ID_TAG = "clientId";
+    public static final String CLIENT_ID_SNAKE_CASE_TAG = "client_id";
     public static final String AUTH_RESOURCES_TAG = "authorizationResources";
     public static final String CONSENT_MAPPING_RESOURCES_TAG = "consentMappingResources";
     public static final String AUTH_TYPE_TAG = "authorizationType";
@@ -51,6 +53,13 @@ public class CDSAccountValidationConstants {
     public static final String ERROR_DESCRIPTION = "ERROR_DESCRIPTION";
     public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
 
+    // Single-account validation error constants
+    public static final String RESOURCE_INVALID_BANKING_ACCOUNT =
+            "urn:au-cds:error:cds-banking:Authorisation/InvalidBankingAccount";
+    public static final String INVALID_BANKING_ACCOUNT_TITLE = "Invalid Banking Account";
+    public static final String INVALID_BANKING_ACCOUNT_DESC =
+            "The accountId requested is not available for data sharing";
+    public static final String HTTP_SC_404 = "404";
 
     // Constants related to DOMS
     public static final String ACCOUNT_IDS_TAG = "accountIds";
@@ -62,6 +71,12 @@ public class CDSAccountValidationConstants {
     public static final String DISCLOSURE_OPTIONS_PATH = "/disclosure-options";
     public static final String SECONDARY_ACCOUNTS_PATH = "/secondary-accounts";
     public static final String BUSINESS_STAKEHOLDERS_PATH = "/business-stakeholders";
+    public static final String LEGAL_ENTITY_SHARING_PATH = "/legal-entity";
+
+    // Legal entity sharing response fields
+    public static final String LEGAL_ENTITY_SHARING_STATUS_TAG = "legalEntitySharingStatus";
+    public static final String LEGAL_ENTITY_SHARING_STATUS_BLOCKED = "blocked";
+    public static final String ACCOUNT_ID_UPPER_CASE_TAG = "accountID";
 
     // Constants related to Secondary Accounts
     public static final String SECONDARY_ACCOUNT_INSTRUCTION_STATUS_TAG = "secondaryAccountInstructionStatus";
@@ -69,14 +84,37 @@ public class CDSAccountValidationConstants {
     public static final String SECONDARY_INDIVIDUAL_ACCOUNT_OWNER_TAG = "secondary_individual_account_owner";
     public static final String SECONDARY_JOINT_ACCOUNT_OWNER_TAG = "secondary_joint_account_owner";
 
+    // Message context properties
+    public static final String API_ELECTED_RESOURCE = "API_ELECTED_RESOURCE";
+    public static final String REST_FULL_REQUEST_PATH = "REST_FULL_REQUEST_PATH";
+    public static final String API_ELECTED_RESOURCE_ACCOUNT_ID_PARAMETER = "{accountId}";
+    public static final String RESOURCE_ACCOUNTS_TAG = "accounts";
+
     // Constants related to Business Accounts
     public static final String NOMINATED_REPRESENTATIVE_TAG = "nominated_representative";
     public static final String BUSINESS_ACCOUNT_OWNER_TAG = "business_account_owner";
     public static final String BUSINESS_PERMISSION_TAG = "permission";
     public static final String BUSINESS_PERMISSION_AUTHORIZE = "AUTHORIZE";
 
-    // Timeouts
-    public static final int HTTP_CLIENT_CONNECT_TIMEOUT_MILLIS = 3000;
-    public static final int HTTP_REQUEST_TIMEOUT_MILLIS = 3000;
+    // HTTP Method
+    public static final String REST_METHOD = "REST_METHOD";
+    public static final String POST_METHOD = "POST";
 
+    // POST request body property key (synapse messageContext property name)
+    public static final String ORIGINAL_REQUEST_JSON_BODY = "originalRequestJsonBody";
+
+    // POST payload field names
+    public static final String DATA_TAG = "data";
+    public static final String POST_PAYLOAD_ACCOUNT_IDS_TAG = "accountIds";
+
+    // HTTP Status Codes (422 is missing)
+    public static final String HTTP_SC_422 = "422";
+
+    // POST error description (reuse existing RESOURCE_INVALID_BANKING_ACCOUNT and INVALID_BANKING_ACCOUNT_TITLE)
+    public static final String INVALID_BANKING_ACCOUNT_POST_DESC =
+        "ID of the account not found or invalid";
+
+    // Timeouts
+    public static final int HTTP_CLIENT_CONNECT_TIMEOUT_MILLIS = 5000;
+    public static final int HTTP_REQUEST_TIMEOUT_MILLIS = 10000;
 }

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
@@ -26,9 +26,16 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import lombok.Setter;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,15 +43,11 @@ import org.wso2.openbanking.consumerdatastandards.au.policy.constants.CDSAccount
 import org.wso2.openbanking.consumerdatastandards.au.policy.exceptions.CDSAccountValidationException;
 
 import java.io.IOException;
-import java.net.URI;
+import java.io.InputStream;
 import java.net.URLEncoder;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.text.ParseException;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -56,9 +59,7 @@ public class CDSAccountValidationUtils {
     private static final Log log = LogFactory.getLog(CDSAccountValidationUtils.class);
 
     @Setter
-    private static HttpClient httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofMillis(CDSAccountValidationConstants.HTTP_CLIENT_CONNECT_TIMEOUT_MILLIS))
-            .build();
+    private static CloseableHttpClient apacheHttpClient;
 
     private static final RSASSASigner SIGNER;
     private static final JWSHeader JWT_HEADER;
@@ -77,6 +78,12 @@ public class CDSAccountValidationUtils {
         JWT_HEADER = new JWSHeader.Builder(JWSAlgorithm.RS512)
                 .type(JOSEObjectType.JWT)
                 .build();
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CDSAccountValidationConstants.HTTP_CLIENT_CONNECT_TIMEOUT_MILLIS)
+                .setSocketTimeout(CDSAccountValidationConstants.HTTP_REQUEST_TIMEOUT_MILLIS)
+                .build();
+        apacheHttpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
     }
 
 
@@ -102,17 +109,18 @@ public class CDSAccountValidationUtils {
     }
 
     /**
-     * Fetch all blocked account IDs by checking both the disclosure options
-     * and secondary accounts services.
+     * Fetch all blocked account IDs by checking disclosure options, secondary accounts,
+     * business stakeholders, and legal-entity sharing status.
      *
      * @param accountIds set of account IDs to check
      * @param baseUrl base URL of the account metadata webapp
-     * @param userId user ID for the secondary accounts query
+     * @param userId user ID for account metadata queries
      * @param basicAuthBase64 Base64-encoded Basic Auth credentials
-     * @return combined set of blocked account IDs from both services
+     * @param clientId software product client ID used to resolve legal_entity_id
+     * @return combined set of blocked account IDs
      */
     public static Set<String> fetchAllBlockedAccounts(
-            Set<String> accountIds, String baseUrl, String userId, String basicAuthBase64)
+            Set<String> accountIds, String baseUrl, String userId, String basicAuthBase64, String clientId)
             throws CDSAccountValidationException {
 
         if (StringUtils.isBlank(userId)) {
@@ -123,6 +131,7 @@ public class CDSAccountValidationUtils {
         String disclosureOptionsApi = baseUrl + CDSAccountValidationConstants.DISCLOSURE_OPTIONS_PATH;
         String secondaryAccountsApi = baseUrl + CDSAccountValidationConstants.SECONDARY_ACCOUNTS_PATH;
         String businessStakeholdersApi = baseUrl + CDSAccountValidationConstants.BUSINESS_STAKEHOLDERS_PATH;
+        String legalEntitySharingApi = baseUrl + CDSAccountValidationConstants.LEGAL_ENTITY_SHARING_PATH;
 
         Set<String> blockedAccounts = fetchBlockedJointAccountsFromService(accountIds, disclosureOptionsApi,
                 basicAuthBase64);
@@ -130,12 +139,16 @@ public class CDSAccountValidationUtils {
                 secondaryAccountsApi, userId, basicAuthBase64);
         Set<String> blockedBusinessAccounts = fetchBlockedBusinessAccountsFromService(accountIds,
                 businessStakeholdersApi, userId, basicAuthBase64);
+        Set<String> blockedLegalEntityAccounts = fetchBlockedLegalEntityAccountsFromService(accountIds,
+                legalEntitySharingApi, userId, basicAuthBase64, clientId);
 
         blockedAccounts.addAll(blockedSecondaryAccounts);
         blockedAccounts.addAll(blockedBusinessAccounts);
+        blockedAccounts.addAll(blockedLegalEntityAccounts);
 
         return blockedAccounts;
     }
+
 
     /**
      * Call disclosure options GET endpoint and return blocked account IDs.
@@ -159,56 +172,49 @@ public class CDSAccountValidationUtils {
             String accountIdsParam = URLEncoder.encode(String.join(",", accountIds), StandardCharsets.UTF_8);
             String requestUrl = blockedAccountsApi + "?" + CDSAccountValidationConstants.ACCOUNT_IDS_TAG + "="
                     + accountIdsParam;
-            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(requestUrl))
-                    .timeout(Duration.ofMillis(CDSAccountValidationConstants.HTTP_REQUEST_TIMEOUT_MILLIS))
-                    .header(CDSAccountValidationConstants.ACCEPT_TAG, CDSAccountValidationConstants.JSON_CONTENT_TYPE)
-                    .GET();
 
-            requestBuilder.header(CDSAccountValidationConstants.AUTH_HEADER,
+            HttpGet request = new HttpGet(requestUrl);
+            request.addHeader(CDSAccountValidationConstants.ACCEPT_TAG,
+                    CDSAccountValidationConstants.JSON_CONTENT_TYPE);
+            request.addHeader(CDSAccountValidationConstants.AUTH_HEADER,
                     CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
 
-            HttpRequest request = requestBuilder.build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 200) {
-                JSONArray disclosureOptions;
-                try {
-                    disclosureOptions = new JSONArray(response.body());
-                } catch (JSONException e) {
-                    String errorMessage = "Invalid disclosure options service response";
-                    log.error(errorMessage, e);
-                    throw new CDSAccountValidationException(errorMessage, e);
-                }
-
-                for (int i = 0; i < disclosureOptions.length(); i++) {
-                    JSONObject accountDisclosure = disclosureOptions.optJSONObject(i);
-                    if (accountDisclosure == null) {
-                        continue;
+            try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 200) {
+                    String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                    JSONArray disclosureOptions;
+                    try {
+                        disclosureOptions = new JSONArray(responseBody);
+                    } catch (JSONException e) {
+                        String errorMessage = "Invalid disclosure options service response";
+                        log.error(errorMessage, e);
+                        throw new CDSAccountValidationException(errorMessage, e);
                     }
 
-                    String disclosureOption =
-                            accountDisclosure.optString(CDSAccountValidationConstants.DISCLOSURE_OPTION_TAG, null);
-                    if (CDSAccountValidationConstants.DOMS_STATUS_NO_SHARING.equalsIgnoreCase(disclosureOption)) {
-                        String accountId = accountDisclosure.optString(
-                                CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
-                        if (StringUtils.isNotBlank(accountId)) {
-                            blockedAccounts.add(accountId);
+                    for (int i = 0; i < disclosureOptions.length(); i++) {
+                        JSONObject accountDisclosure = disclosureOptions.optJSONObject(i);
+                        if (accountDisclosure == null) {
+                            continue;
+                        }
+                        String disclosureOption = accountDisclosure.optString(
+                                CDSAccountValidationConstants.DISCLOSURE_OPTION_TAG, null);
+                        if (CDSAccountValidationConstants.DOMS_STATUS_NO_SHARING.equalsIgnoreCase(disclosureOption)) {
+                            String accountId = accountDisclosure.optString(
+                                    CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
+                            if (StringUtils.isNotBlank(accountId)) {
+                                blockedAccounts.add(accountId);
+                            }
                         }
                     }
+                } else {
+                    String errorMessage = "Disclosure options service returned HTTP " + statusCode;
+                    log.error(errorMessage);
+                    throw new CDSAccountValidationException(errorMessage);
                 }
-            } else {
-                String errorMessage = "Disclosure options service returned HTTP " + response.statusCode();
-                log.error(errorMessage);
-                throw new CDSAccountValidationException(errorMessage);
             }
-
         } catch (IOException e) {
             String errorMessage = "[DOMS] Error calling disclosure options service";
-            log.error(errorMessage, e);
-            throw new CDSAccountValidationException(errorMessage, e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            String errorMessage = "[DOMS] Interrupted while calling disclosure options service";
             log.error(errorMessage, e);
             throw new CDSAccountValidationException(errorMessage, e);
         }
@@ -242,57 +248,49 @@ public class CDSAccountValidationUtils {
             String requestUrl = secondaryAccountsApi + "?" + CDSAccountValidationConstants.ACCOUNT_IDS_TAG + "="
                     + accountIdsParam + "&" + CDSAccountValidationConstants.USER_ID_TAG + "=" + userIdParam;
 
-            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(requestUrl))
-                    .timeout(Duration.ofMillis(CDSAccountValidationConstants.HTTP_REQUEST_TIMEOUT_MILLIS))
-                    .header(CDSAccountValidationConstants.ACCEPT_TAG,
-                            CDSAccountValidationConstants.JSON_CONTENT_TYPE).GET();
-
-            requestBuilder.header(CDSAccountValidationConstants.AUTH_HEADER,
+            HttpGet request = new HttpGet(requestUrl);
+            request.addHeader(CDSAccountValidationConstants.ACCEPT_TAG,
+                    CDSAccountValidationConstants.JSON_CONTENT_TYPE);
+            request.addHeader(CDSAccountValidationConstants.AUTH_HEADER,
                     CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
 
-            HttpRequest request = requestBuilder.build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 200) {
-                JSONArray secondaryAccounts;
-                try {
-                    secondaryAccounts = new JSONArray(response.body());
-                } catch (JSONException e) {
-                    String errorMessage = "Invalid secondary accounts service response";
-                    log.error(errorMessage, e);
-                    throw new CDSAccountValidationException(errorMessage, e);
-                }
-
-                for (int i = 0; i < secondaryAccounts.length(); i++) {
-                    JSONObject accountInstruction = secondaryAccounts.optJSONObject(i);
-                    if (accountInstruction == null) {
-                        continue;
+            try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 200) {
+                    String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                    JSONArray secondaryAccounts;
+                    try {
+                        secondaryAccounts = new JSONArray(responseBody);
+                    } catch (JSONException e) {
+                        String errorMessage = "Invalid secondary accounts service response";
+                        log.error(errorMessage, e);
+                        throw new CDSAccountValidationException(errorMessage, e);
                     }
-                    String instructionStatus = accountInstruction.optString(
-                            CDSAccountValidationConstants.SECONDARY_ACCOUNT_INSTRUCTION_STATUS_TAG, null);
 
-                    if (CDSAccountValidationConstants.SECONDARY_ACCOUNT_STATUS_INACTIVE
-                            .equalsIgnoreCase(instructionStatus)) {
-                        String accountId = accountInstruction.optString(
-                                CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
-                        if (StringUtils.isNotBlank(accountId)) {
-                            blockedAccounts.add(accountId);
+                    for (int i = 0; i < secondaryAccounts.length(); i++) {
+                        JSONObject accountInstruction = secondaryAccounts.optJSONObject(i);
+                        if (accountInstruction == null) {
+                            continue;
+                        }
+                        String instructionStatus = accountInstruction.optString(
+                                CDSAccountValidationConstants.SECONDARY_ACCOUNT_INSTRUCTION_STATUS_TAG, null);
+                        if (CDSAccountValidationConstants.SECONDARY_ACCOUNT_STATUS_INACTIVE
+                                .equalsIgnoreCase(instructionStatus)) {
+                            String accountId = accountInstruction.optString(
+                                    CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
+                            if (StringUtils.isNotBlank(accountId)) {
+                                blockedAccounts.add(accountId);
+                            }
                         }
                     }
+                } else {
+                    String errorMessage = "Secondary accounts service returned HTTP " + statusCode;
+                    log.error(errorMessage);
+                    throw new CDSAccountValidationException(errorMessage);
                 }
-            } else {
-                String errorMessage = "Secondary accounts service returned HTTP " + response.statusCode();
-                log.error(errorMessage);
-                throw new CDSAccountValidationException(errorMessage);
             }
-
         } catch (IOException e) {
             String errorMessage = "[SecondaryAccounts] Error calling secondary accounts service";
-            log.error(errorMessage, e);
-            throw new CDSAccountValidationException(errorMessage, e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            String errorMessage = "[SecondaryAccounts] Interrupted while calling secondary accounts service";
             log.error(errorMessage, e);
             throw new CDSAccountValidationException(errorMessage, e);
         }
@@ -325,62 +323,137 @@ public class CDSAccountValidationUtils {
             String requestUrl = businessStakeholdersApi + "?" + CDSAccountValidationConstants.ACCOUNT_IDS_TAG + "="
                     + accountIdsParam + "&" + CDSAccountValidationConstants.USER_ID_TAG + "=" + userIdParam;
 
-            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(requestUrl))
-                    .timeout(Duration.ofMillis(CDSAccountValidationConstants.HTTP_REQUEST_TIMEOUT_MILLIS))
-                    .header(CDSAccountValidationConstants.ACCEPT_TAG,
-                            CDSAccountValidationConstants.JSON_CONTENT_TYPE).GET();
+            HttpGet request = new HttpGet(requestUrl);
+            request.addHeader(CDSAccountValidationConstants.ACCEPT_TAG,
+                    CDSAccountValidationConstants.JSON_CONTENT_TYPE);
+            request.addHeader(CDSAccountValidationConstants.AUTH_HEADER,
+                    CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
 
-            if (StringUtils.isNotBlank(basicAuthBase64)) {
-                requestBuilder.header(CDSAccountValidationConstants.AUTH_HEADER,
-                        CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
-            } else {
-                String errorMessage = "[BusinessStakeholders] Basic Auth property not set, request may fail";
-                log.error(errorMessage);
-                throw new CDSAccountValidationException(errorMessage);
-            }
-
-            HttpRequest request = requestBuilder.build();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() == 200) {
-                JSONArray businessStakeholders;
-                try {
-                    businessStakeholders = new JSONArray(response.body());
-                } catch (JSONException e) {
-                    String errorMessage = "Invalid business stakeholders service response";
-                    log.error(errorMessage, e);
-                    throw new CDSAccountValidationException(errorMessage, e);
-                }
-
-                for (int i = 0; i < businessStakeholders.length(); i++) {
-                    JSONObject permissionItem = businessStakeholders.optJSONObject(i);
-                    if (permissionItem == null) {
-                        continue;
+            try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 200) {
+                    String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                    JSONArray businessStakeholders;
+                    try {
+                        businessStakeholders = new JSONArray(responseBody);
+                    } catch (JSONException e) {
+                        String errorMessage = "Invalid business stakeholders service response";
+                        log.error(errorMessage, e);
+                        throw new CDSAccountValidationException(errorMessage, e);
                     }
 
-                    String permission = permissionItem.optString(
-                            CDSAccountValidationConstants.BUSINESS_PERMISSION_TAG, null);
-                    if (!CDSAccountValidationConstants.BUSINESS_PERMISSION_AUTHORIZE.equalsIgnoreCase(permission)) {
-                        String accountId = permissionItem.optString(
-                                CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
-                        if (StringUtils.isNotBlank(accountId)) {
-                            blockedAccounts.add(accountId);
+                    for (int i = 0; i < businessStakeholders.length(); i++) {
+                        JSONObject permissionItem = businessStakeholders.optJSONObject(i);
+                        if (permissionItem == null) {
+                            continue;
+                        }
+                        String permission = permissionItem.optString(
+                                CDSAccountValidationConstants.BUSINESS_PERMISSION_TAG, null);
+                        if (!CDSAccountValidationConstants.BUSINESS_PERMISSION_AUTHORIZE
+                                .equalsIgnoreCase(permission)) {
+                            String accountId = permissionItem.optString(
+                                    CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null);
+                            if (StringUtils.isNotBlank(accountId)) {
+                                blockedAccounts.add(accountId);
+                            }
                         }
                     }
+                } else {
+                    String errorMessage = "Business stakeholders service returned HTTP " + statusCode;
+                    log.error(errorMessage);
+                    throw new CDSAccountValidationException(errorMessage);
                 }
-            } else {
-                String errorMessage = "Business stakeholders service returned HTTP " + response.statusCode();
-                log.error(errorMessage);
-                throw new CDSAccountValidationException(errorMessage);
             }
-
         } catch (IOException e) {
             String errorMessage = "[BusinessStakeholders] Error calling business stakeholders service";
             log.error(errorMessage, e);
             throw new CDSAccountValidationException(errorMessage, e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            String errorMessage = "[BusinessStakeholders] Interrupted while calling business stakeholders service";
+        }
+        return blockedAccounts;
+    }
+
+    /**
+     * Call legal-entity GET endpoint and return blocked account IDs for the requesting client's legal entity.
+     * The {@code clientId} is forwarded to the account-metadata service, which resolves it to a legal entity ID
+     * via the IS server and filters the response accordingly.
+     *
+     * @param accountIds set of account IDs to check
+     * @param legalEntitySharingApi legal-entity API endpoint
+     * @param userId user ID for the legal-entity query
+     * @param basicAuthBase64 Base64-encoded Basic Auth credentials
+     * @param clientId software product client ID
+     * @return set of blocked account IDs by legal entity
+     */
+    static Set<String> fetchBlockedLegalEntityAccountsFromService
+    (Set<String> accountIds, String legalEntitySharingApi, String userId, String basicAuthBase64, String clientId)
+            throws CDSAccountValidationException {
+
+        Set<String> blockedAccounts = new HashSet<>();
+
+        if (accountIds == null || accountIds.isEmpty() || StringUtils.isBlank(clientId)) {
+            return blockedAccounts;
+        }
+
+        try {
+            String accountIdsParam = URLEncoder.encode(String.join(",", accountIds), StandardCharsets.UTF_8);
+            String userIdParam = URLEncoder.encode(userId, StandardCharsets.UTF_8);
+            String clientIdParam = URLEncoder.encode(clientId, StandardCharsets.UTF_8);
+            String requestUrl = legalEntitySharingApi + "?" + CDSAccountValidationConstants.ACCOUNT_IDS_TAG + "="
+                    + accountIdsParam + "&" + CDSAccountValidationConstants.USER_ID_TAG + "=" + userIdParam
+                    + "&" + CDSAccountValidationConstants.CLIENT_ID_TAG + "=" + clientIdParam;
+
+            HttpGet request = new HttpGet(requestUrl);
+            request.addHeader(CDSAccountValidationConstants.ACCEPT_TAG,
+                    CDSAccountValidationConstants.JSON_CONTENT_TYPE);
+            if (StringUtils.isNotBlank(basicAuthBase64)) {
+                request.addHeader(CDSAccountValidationConstants.AUTH_HEADER,
+                        CDSAccountValidationConstants.BASIC_TAG + basicAuthBase64);
+            }
+
+            try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 200) {
+                    String responseBody;
+                    try (InputStream inputStream = response.getEntity().getContent()) {
+                        responseBody = IOUtils.toString(inputStream, "UTF-8");
+                    }
+
+                    JSONArray legalEntitySharingItems;
+                    try {
+                        legalEntitySharingItems = new JSONArray(responseBody);
+                    } catch (JSONException e) {
+                        String errorMessage = "Invalid legal entity sharing service response";
+                        log.error(errorMessage, e);
+                        throw new CDSAccountValidationException(errorMessage, e);
+                    }
+
+                    for (int i = 0; i < legalEntitySharingItems.length(); i++) {
+                        JSONObject sharingItem = legalEntitySharingItems.optJSONObject(i);
+                        if (sharingItem == null) {
+                            continue;
+                        }
+
+                        String sharingStatus = sharingItem.optString(
+                                CDSAccountValidationConstants.LEGAL_ENTITY_SHARING_STATUS_TAG, null);
+
+                        if (CDSAccountValidationConstants.LEGAL_ENTITY_SHARING_STATUS_BLOCKED
+                                .equalsIgnoreCase(sharingStatus)) {
+                            String accountId = sharingItem.optString(
+                                    CDSAccountValidationConstants.ACCOUNT_ID_UPPER_CASE_TAG, sharingItem.optString(
+                                            CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, null));
+                            if (StringUtils.isNotBlank(accountId)) {
+                                blockedAccounts.add(accountId);
+                            }
+                        }
+                    }
+                } else {
+                    String errorMessage = "Legal-entity service returned HTTP " + statusCode;
+                    log.error(errorMessage);
+                    throw new CDSAccountValidationException(errorMessage);
+                }
+            }
+        } catch (IOException e) {
+            String errorMessage = "[LegalEntity] Error calling legal-entity service";
             log.error(errorMessage, e);
             throw new CDSAccountValidationException(errorMessage, e);
         }

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtils.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -181,7 +182,7 @@ public class CDSAccountValidationUtils {
 
             try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
                 int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == 200) {
+                if (statusCode == HttpStatus.SC_OK) {
                     String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                     JSONArray disclosureOptions;
                     try {
@@ -256,7 +257,7 @@ public class CDSAccountValidationUtils {
 
             try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
                 int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == 200) {
+                if (statusCode == HttpStatus.SC_OK) {
                     String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                     JSONArray secondaryAccounts;
                     try {
@@ -331,7 +332,7 @@ public class CDSAccountValidationUtils {
 
             try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
                 int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == 200) {
+                if (statusCode == HttpStatus.SC_OK) {
                     String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
                     JSONArray businessStakeholders;
                     try {
@@ -412,7 +413,7 @@ public class CDSAccountValidationUtils {
 
             try (CloseableHttpResponse response = apacheHttpClient.execute(request)) {
                 int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == 200) {
+                if (statusCode == HttpStatus.SC_OK) {
                     String responseBody;
                     try (InputStream inputStream = response.getEntity().getContent()) {
                         responseBody = IOUtils.toString(inputStream, "UTF-8");

--- a/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/KeyStoreUtils.java
+++ b/components/policies/cds-account-validation-policy/src/main/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/KeyStoreUtils.java
@@ -87,5 +87,4 @@ public class KeyStoreUtils {
 
         serverConfigs = config;
     }
-
 }

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
@@ -33,9 +33,6 @@ import org.wso2.openbanking.consumerdatastandards.au.policy.constants.CDSAccount
 import org.wso2.openbanking.consumerdatastandards.au.policy.exceptions.CDSAccountValidationException;
 import org.wso2.openbanking.consumerdatastandards.au.policy.utils.CDSAccountValidationUtils;
 
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,60 +60,7 @@ public class CDSAccountValidationMediatorTest {
     }
 
     /**
-     * Verifies mediation falls back to policy error handling when account filtering/signing flow fails.
-     */
-    @Test
-    public void testMediateFiltersBlockedAccountsAndUpdatesHeader() throws Exception {
-        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("["
-                + "{\"accountId\":\"acc-2\",\"disclosureOption\":\"no-sharing\"},"
-                + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"pre-approval\"}"
-                + "]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
-
-        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
-        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
-
-        JSONObject payload = new JSONObject();
-        JSONArray authorizationResources = new JSONArray();
-        authorizationResources.put(new JSONObject()
-                .put("authorizationType", "linkedMember")
-                .put("authorizationId", "linked-1"));
-        authorizationResources.put(new JSONObject()
-                .put("authorizationType", "user")
-                .put("authorizationId", "auth-2"));
-        payload.put("authorizationResources", authorizationResources);
-
-        JSONArray accounts = new JSONArray();
-        accounts.put(new JSONObject().put("account_id", "acc-1"));
-        accounts.put(new JSONObject().put("account_id", "acc-2"));
-        accounts.put(new JSONObject().put("account_id", "acc-3").put("authorizationId", "linked-1"));
-        payload.put("consentMappingResources", accounts);
-
-        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
-
-        boolean result = mediator.mediate(synapseMessageContext);
-
-        Assert.assertTrue(result);
-        Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
-                "Internal Server Error");
-        Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
-                "CDS DOMS Policy Error");
-        Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.CUSTOM_HTTP_SC,
-                "500");
-        Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_DESCRIPTION,
-                "Error during CDS mediation policy");
-    }
-
-    /**
-     * Verifies invalid info-header payloads are handled by setting policy error properties.
+     * Verifies invalid info-header payloads are handled by throwing exception and setting policy error properties.
      */
     @Test
     public void testMediateHandlesDecodeError() throws Exception {
@@ -124,9 +68,9 @@ public class CDSAccountValidationMediatorTest {
 
         headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, "{not-json");
 
-        boolean result = mediator.mediate(synapseMessageContext);
+        Assert.assertThrows(org.apache.synapse.SynapseException.class,
+                () -> mediator.mediate(synapseMessageContext));
 
-        Assert.assertTrue(result);
         Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
                 "Internal Server Error");
         Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
@@ -174,7 +118,7 @@ public class CDSAccountValidationMediatorTest {
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
                             Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
-                            Mockito.eq("dGVzdDp0ZXN0")))
+                            Mockito.eq("dGVzdDp0ZXN0"), Mockito.anyString()))
                     .thenReturn(Collections.singleton("acc-2"));
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
                     .thenReturn("signed-jwt");
@@ -185,7 +129,7 @@ public class CDSAccountValidationMediatorTest {
             Assert.assertEquals(headers.get(CDSAccountValidationConstants.INFO_HEADER_TAG), "signed-jwt");
             utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
                     Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL), Mockito.eq("user-1"),
-                    Mockito.eq("dGVzdDp0ZXN0")));
+                    Mockito.eq("dGVzdDp0ZXN0"), Mockito.anyString()));
             utilsMock.verify(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()));
         }
     }
@@ -209,14 +153,15 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenReturn(Collections.emptySet());
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
                     .thenThrow(new JOSEException("signing failed"));
 
-            boolean result = mediator.mediate(synapseMessageContext);
+            Assert.assertThrows(org.apache.synapse.SynapseException.class,
+                    () -> mediator.mediate(synapseMessageContext));
 
-            Assert.assertTrue(result);
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
                     "Internal Server Error");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
@@ -225,6 +170,37 @@ public class CDSAccountValidationMediatorTest {
                     "500");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_DESCRIPTION,
                     "Error during CDS mediation policy");
+        }
+    }
+
+    @Test
+    public void testMediateWithNoAuthorizationResources() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.isNull(),
+                            Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Collections.emptySet());
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            Assert.assertEquals(headers.get(CDSAccountValidationConstants.INFO_HEADER_TAG), "signed-jwt");
+            Mockito.verify(synapseMessageContext, Mockito.never())
+                    .setProperty(Mockito.eq(CDSAccountValidationConstants.ERROR_CODE), Mockito.any());
         }
     }
 
@@ -245,41 +221,6 @@ public class CDSAccountValidationMediatorTest {
         Assert.assertTrue(result);
         Mockito.verify(synapseMessageContext, Mockito.never())
                 .setProperty(Mockito.eq(CDSAccountValidationConstants.ERROR_CODE), Mockito.any());
-    }
-
-    /**
-     * Verifies mediation proceeds with a null user context when authorization resources are absent.
-     */
-    @Test
-    public void testMediateWithNoAuthorizationResources() throws Exception {
-        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
-        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
-        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
-
-        JSONObject payload = new JSONObject();
-        // No authorizationResources — userId stays null, no accounts excluded
-        JSONArray accounts = new JSONArray();
-        accounts.put(new JSONObject()
-                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
-                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
-        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
-        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
-
-        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
-            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.isNull(), Mockito.anyString()))
-                    .thenReturn(Collections.emptySet());
-            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
-                    .thenReturn("signed-jwt");
-
-            boolean result = mediator.mediate(synapseMessageContext);
-
-            Assert.assertTrue(result);
-            // userId should be null because there were no authorizationResources
-            utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                    Mockito.anySet(), Mockito.eq(ACCOUNT_METADATA_WEBAPP_BASE_URL),
-                    Mockito.isNull(), Mockito.eq("dGVzdDp0ZXN0")));
-        }
     }
 
     /**
@@ -322,7 +263,8 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenReturn(Collections.emptySet());
             utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
                     .thenReturn("signed-jwt");
@@ -330,12 +272,10 @@ public class CDSAccountValidationMediatorTest {
             boolean result = mediator.mediate(synapseMessageContext);
 
             Assert.assertTrue(result);
-            // Only the primary account should be passed to fetchAllBlockedAccounts;
-            // secondary account owner accounts are excluded from validation.
             @SuppressWarnings("unchecked")
             ArgumentCaptor<Set<String>> accountIdsCaptor = ArgumentCaptor.forClass(Set.class);
             utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                    accountIdsCaptor.capture(), Mockito.any(), Mockito.any(), Mockito.any()));
+                    accountIdsCaptor.capture(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()));
             Assert.assertEquals(accountIdsCaptor.getValue().size(), 1);
             Assert.assertTrue(accountIdsCaptor.getValue().contains("acc-primary"));
         }
@@ -370,7 +310,8 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenReturn(Collections.emptySet());
 
             ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
@@ -435,7 +376,8 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenReturn(Collections.emptySet());
 
             ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
@@ -445,15 +387,13 @@ public class CDSAccountValidationMediatorTest {
             boolean result = mediator.mediate(synapseMessageContext);
 
             Assert.assertTrue(result);
-            // Only the primary account is passed to fetchAllBlockedAccounts
             @SuppressWarnings("unchecked")
             ArgumentCaptor<Set<String>> accountIdsCaptor = ArgumentCaptor.forClass(Set.class);
             utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                    accountIdsCaptor.capture(), Mockito.any(), Mockito.any(), Mockito.any()));
+                    accountIdsCaptor.capture(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()));
             Assert.assertEquals(accountIdsCaptor.getValue().size(), 1);
             Assert.assertTrue(accountIdsCaptor.getValue().contains("acc-primary"));
 
-            // Business accounts must also be excluded from consentMappingResources in the signed JWT
             JSONObject capturedJson = new JSONObject(jwtPayloadCaptor.getValue());
             JSONArray filteredMappings = capturedJson
                     .getJSONArray(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG);
@@ -489,7 +429,8 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenReturn(Set.of("acc-1", "acc-2"));
 
             ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
@@ -538,7 +479,8 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenReturn(Collections.singleton("acc-blocked"));
 
             ArgumentCaptor<String> jwtPayloadCaptor = ArgumentCaptor.forClass(String.class);
@@ -550,7 +492,6 @@ public class CDSAccountValidationMediatorTest {
             Assert.assertTrue(result);
             JSONObject capturedJson = new JSONObject(jwtPayloadCaptor.getValue());
 
-            // linked_member must be removed from authorizationResources in the signed payload
             JSONArray filteredAuth = capturedJson.getJSONArray(CDSAccountValidationConstants.AUTH_RESOURCES_TAG);
             Assert.assertEquals(filteredAuth.length(), 1);
             Assert.assertEquals(filteredAuth.getJSONObject(0)
@@ -585,12 +526,13 @@ public class CDSAccountValidationMediatorTest {
 
         try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
             utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.anyString()))
                     .thenThrow(new CDSAccountValidationException("metadata service unavailable"));
 
-            boolean result = mediator.mediate(synapseMessageContext);
+            Assert.assertThrows(org.apache.synapse.SynapseException.class,
+                    () -> mediator.mediate(synapseMessageContext));
 
-            Assert.assertTrue(result);
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_CODE,
                     "Internal Server Error");
             Mockito.verify(synapseMessageContext).setProperty(CDSAccountValidationConstants.ERROR_TITLE,
@@ -601,4 +543,43 @@ public class CDSAccountValidationMediatorTest {
                     "Error during CDS mediation policy");
         }
     }
+
+    @Test
+    public void testMediatePassesClientIdFromPayload() throws Exception {
+        CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
+        mediator.setWebappBaseURL(ACCOUNT_METADATA_WEBAPP_BASE_URL);
+        mediator.setBasicAuthCredentials("dGVzdDp0ZXN0");
+
+        JSONObject payload = new JSONObject();
+        payload.put(CDSAccountValidationConstants.CLIENT_ID_TAG, "my-client-id");
+        JSONArray authorizationResources = new JSONArray();
+        authorizationResources.put(new JSONObject()
+                .put(CDSAccountValidationConstants.AUTH_TYPE_TAG, CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG)
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1")
+                .put(CDSAccountValidationConstants.USER_ID_TAG, "user-1"));
+        payload.put(CDSAccountValidationConstants.AUTH_RESOURCES_TAG, authorizationResources);
+        JSONArray accounts = new JSONArray();
+        accounts.put(new JSONObject()
+                .put(CDSAccountValidationConstants.ACCELERATOR_ACCOUNT_ID_TAG, "acc-1")
+                .put(CDSAccountValidationConstants.AUTH_ID_TAG, "auth-1"));
+        payload.put(CDSAccountValidationConstants.CONSENT_MAPPING_RESOURCES_TAG, accounts);
+        headers.put(CDSAccountValidationConstants.INFO_HEADER_TAG, payload.toString());
+
+        try (MockedStatic<CDSAccountValidationUtils> utilsMock = Mockito.mockStatic(CDSAccountValidationUtils.class)) {
+            utilsMock.when(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                            Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                            Mockito.anyString(), Mockito.eq("my-client-id")))
+                    .thenReturn(Collections.emptySet());
+            utilsMock.when(() -> CDSAccountValidationUtils.generateJWT(Mockito.anyString()))
+                    .thenReturn("signed-jwt");
+
+            boolean result = mediator.mediate(synapseMessageContext);
+
+            Assert.assertTrue(result);
+            utilsMock.verify(() -> CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                    Mockito.anySet(), Mockito.anyString(), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.eq("my-client-id")));
+        }
+    }
+
 }

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/CDSAccountValidationMediatorTest.java
@@ -173,6 +173,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies mediation succeeds when no authorization resources are present in the payload.
+     */
     @Test
     public void testMediateWithNoAuthorizationResources() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -403,6 +406,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies all accounts are filtered out when they are all blocked.
+     */
     @Test
     public void testMediateAllAccountsBlocked() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -447,6 +453,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies filtered authorization resources and account mappings are included in the signed JWT payload.
+     */
     @Test
     public void testMediateVerifiesFilteredAuthResourcesAndMappingsInSignedPayload() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -495,7 +504,7 @@ public class CDSAccountValidationMediatorTest {
             JSONArray filteredAuth = capturedJson.getJSONArray(CDSAccountValidationConstants.AUTH_RESOURCES_TAG);
             Assert.assertEquals(filteredAuth.length(), 1);
             Assert.assertEquals(filteredAuth.getJSONObject(0)
-                    .getString(CDSAccountValidationConstants.AUTH_TYPE_TAG),
+                            .getString(CDSAccountValidationConstants.AUTH_TYPE_TAG),
                     CDSAccountValidationConstants.PRIMARY_AUTH_TYPE_TAG);
 
             // acc-linked (excluded) and acc-blocked (blocked) must be absent; only acc-allowed survives
@@ -507,6 +516,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies account validation service failures are translated into mediation error properties.
+     */
     @Test
     public void testMediateSetsErrorPropertiesWhenAccountValidationFails() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -544,6 +556,9 @@ public class CDSAccountValidationMediatorTest {
         }
     }
 
+    /**
+     * Verifies client ID from the payload is passed to the account validation utility.
+     */
     @Test
     public void testMediatePassesClientIdFromPayload() throws Exception {
         CDSAccountValidationMediator mediator = new CDSAccountValidationMediator();
@@ -581,5 +596,4 @@ public class CDSAccountValidationMediatorTest {
                     Mockito.anyString(), Mockito.eq("my-client-id")));
         }
     }
-
 }

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.openbanking.consumerdatastandards.au.policy.utils;
 
+import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -94,7 +95,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsFromServiceSuccess() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"},"
                 + "{\"accountId\":\"acc-2\",\"disclosureOption\":\"pre-approval\"},"
                 + "{\"accountId\":\"acc-3\",\"disclosureOption\":\"no-sharing\"}"
@@ -125,7 +126,8 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsFromServiceNon200() throws Exception {
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(500, "[]"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(
+                HttpStatus.SC_INTERNAL_SERVER_ERROR, "[]"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -156,7 +158,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsWithAuthHeader() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"}"
                 + "]");
         CDSAccountValidationUtils.setApacheHttpClient(client);
@@ -181,7 +183,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsSuccessIncludesRequiredAuthHeader() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "{\"accountId\":\"acc-2\",\"disclosureOption\":\"no-sharing\"}"
                 + "]");
         CDSAccountValidationUtils.setApacheHttpClient(client);
@@ -222,7 +224,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsSkipsInvalidRowsAndBlankAccountId() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "\"invalid\","
                 + "{\"disclosureOption\":\"no-sharing\"},"
                 + "{\"accountId\":\"acc-5\",\"disclosureOption\":\"no-sharing\"}"
@@ -244,7 +246,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsFromServiceMalformedResponse() throws Exception {
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_OK, "{not-an-array"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -261,7 +263,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedSecondaryAccountsSuccess() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "{\"accountId\":\"acc-1\",\"secondaryAccountInstructionStatus\":\"inactive\"},"
                 + "{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"active\"}"
                 + "]");
@@ -284,7 +286,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedSecondaryAccountsNon200() throws Exception {
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(503, "[]"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "[]"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -317,7 +319,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedSecondaryAccountsMalformedResponse() throws Exception {
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_OK, "{not-an-array"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -351,7 +353,7 @@ public class CDSAccountValidationUtilsTest {
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
 
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_OK, "[]"));
         Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
                 accounts, SECONDARY_ACCOUNTS_ENDPOINT, "", BASIC_AUTH);
         Assert.assertNotNull(blockedForBlank);
@@ -367,7 +369,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedSecondaryAccountsIncludesUserIdInRequest() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "[]");
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "[]");
         CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
@@ -390,7 +392,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedSecondaryAccountsSkipsInvalidAndNonInactiveRows() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "\"invalid-string-entry\","
                 + "{\"secondaryAccountInstructionStatus\":\"inactive\"},"
                 + "{\"accountId\":\"acc-active\",\"secondaryAccountInstructionStatus\":\"active\"},"
@@ -417,7 +419,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedBusinessAccountsSuccess() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "{\"accountId\":\"acc-1\",\"permission\":\"VIEW\"},"
                 + "{\"accountId\":\"acc-2\",\"permission\":\"AUTHORIZE\"}"
                 + "]");
@@ -440,7 +442,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedBusinessAccountsNon200() throws Exception {
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(503, "[]"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "[]"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -473,7 +475,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedBusinessAccountsMalformedResponse() throws Exception {
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_OK, "{not-an-array"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -500,14 +502,15 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-     * Verifies blank user ID returns empty results while null user ID raises a NullPointerException for business accounts.
+     * Verifies blank user ID returns empty results while null user ID raises a NullPointerException for
+     * business accounts.
      */
     @Test
     public void testFetchBlockedBusinessAccountsWithBlankUserId() throws Exception {
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
 
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_OK, "[]"));
         Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
                 accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "", BASIC_AUTH);
         Assert.assertNotNull(blockedForBlank);
@@ -523,7 +526,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedBusinessAccountsIncludesUserIdInRequest() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "[]");
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "[]");
         CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
@@ -542,11 +545,12 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-     * Verifies malformed rows and AUTHORIZE permission accounts are skipped while VIEW permission accounts are returned as blocked.
+     * Verifies malformed rows and AUTHORIZE permission accounts are skipped while
+     * VIEW permission accounts are returned as blocked.
      */
     @Test
     public void testFetchBlockedBusinessAccountsSkipsInvalidAndAuthorizeRows() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "["
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "["
                 + "\"invalid-entry\","
                 + "{\"permission\":\"VIEW\"},"
                 + "{\"accountId\":\"acc-auth\",\"permission\":\"AUTHORIZE\"},"
@@ -586,11 +590,11 @@ public class CDSAccountValidationUtilsTest {
     public void testFetchAllBlockedAccountsCombinesResults() throws Exception {
         // Pre-create all responses before the Mockito.when chain to avoid UnfinishedStubbingException
         // (mockResponse internally calls Mockito.when, which must not happen mid-chain).
-        CloseableHttpResponse disclosureResp = mockResponse(200,
+        CloseableHttpResponse disclosureResp = mockResponse(HttpStatus.SC_OK,
                 "[{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"}]");
-        CloseableHttpResponse secondaryResp = mockResponse(200,
+        CloseableHttpResponse secondaryResp = mockResponse(HttpStatus.SC_OK,
                 "[{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"inactive\"}]");
-        CloseableHttpResponse businessResp = mockResponse(200,
+        CloseableHttpResponse businessResp = mockResponse(HttpStatus.SC_OK,
                 "[{\"accountId\":\"acc-3\",\"permission\":\"VIEW\"}]");
 
         // disclosure → secondary → business; legal entity is skipped because clientId is null
@@ -690,7 +694,7 @@ public class CDSAccountValidationUtilsTest {
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
 
-        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(HttpStatus.SC_OK, "[]"));
         Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
                 accounts, LEGAL_ENTITY_ENDPOINT, "", BASIC_AUTH, "client-1");
         Assert.assertNotNull(blockedForBlank);
@@ -719,7 +723,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedLegalEntityAccountsWhenLegalEntityIdBlank() throws Exception {
-        CloseableHttpClient client = mockClientWithResponse(200, "[]");
+        CloseableHttpClient client = mockClientWithResponse(HttpStatus.SC_OK, "[]");
         CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
@@ -743,7 +747,7 @@ public class CDSAccountValidationUtilsTest {
                 + "{\"accountID\":\"acc-2\",\"legalEntitySharingStatus\":\"allowed\"}"
                 + "]";
 
-        CloseableHttpResponse leResp = mockResponse(200, leResponse);
+        CloseableHttpResponse leResp = mockResponse(HttpStatus.SC_OK, leResponse);
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
         Mockito.when(client.execute(Mockito.any(HttpGet.class)))
                 .thenReturn(leResp);
@@ -771,7 +775,7 @@ public class CDSAccountValidationUtilsTest {
                 + "{\"accountId\":\"acc-camel\",\"legalEntitySharingStatus\":\"blocked\"}"
                 + "]";
 
-        CloseableHttpResponse leResp = mockResponse(200, leResponse);
+        CloseableHttpResponse leResp = mockResponse(HttpStatus.SC_OK, leResponse);
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
         Mockito.when(client.execute(Mockito.any(HttpGet.class)))
                 .thenReturn(leResp);
@@ -792,7 +796,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedLegalEntityAccountsNon200() throws Exception {
-        CloseableHttpResponse leResp = mockResponse(503, "[]");
+        CloseableHttpResponse leResp = mockResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "[]");
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
         Mockito.when(client.execute(Mockito.any(HttpGet.class)))
                 .thenReturn(leResp);
@@ -827,7 +831,7 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedLegalEntityAccountsMalformedResponse() throws Exception {
-        CloseableHttpResponse leResp = mockResponse(200, "{not-an-array");
+        CloseableHttpResponse leResp = mockResponse(HttpStatus.SC_OK, "{not-an-array");
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
         Mockito.when(client.execute(Mockito.any(HttpGet.class)))
                 .thenReturn(leResp);
@@ -849,10 +853,10 @@ public class CDSAccountValidationUtilsTest {
     public void testFetchAllBlockedAccountsWithClientId() throws Exception {
         String leBody = "[{\"accountID\":\"acc-1\",\"legalEntitySharingStatus\":\"blocked\"}]";
 
-        CloseableHttpResponse disclosureResp = mockResponse(200, "[]");
-        CloseableHttpResponse secondaryResp = mockResponse(200, "[]");
-        CloseableHttpResponse businessResp = mockResponse(200, "[]");
-        CloseableHttpResponse leResp = mockResponse(200, leBody);
+        CloseableHttpResponse disclosureResp = mockResponse(HttpStatus.SC_OK, "[]");
+        CloseableHttpResponse secondaryResp = mockResponse(HttpStatus.SC_OK, "[]");
+        CloseableHttpResponse businessResp = mockResponse(HttpStatus.SC_OK, "[]");
+        CloseableHttpResponse leResp = mockResponse(HttpStatus.SC_OK, leBody);
 
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
         Mockito.when(client.execute(Mockito.any(HttpGet.class)))

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
@@ -18,19 +18,19 @@
 
 package org.wso2.openbanking.consumerdatastandards.au.policy.utils;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.wso2.openbanking.consumerdatastandards.au.policy.constants.CDSAccountValidationConstants;
 import org.wso2.openbanking.consumerdatastandards.au.policy.exceptions.CDSAccountValidationException;
 
 import java.io.IOException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
@@ -45,27 +45,42 @@ public class CDSAccountValidationUtilsTest {
     private static final String DOMS_ENDPOINT = ACCOUNT_METADATA_WEBAPP_BASE_URL + "/disclosure-options";
     private static final String SECONDARY_ACCOUNTS_ENDPOINT =
             ACCOUNT_METADATA_WEBAPP_BASE_URL + "/secondary-accounts";
+    private static final String BUSINESS_STAKEHOLDERS_ENDPOINT =
+            ACCOUNT_METADATA_WEBAPP_BASE_URL + "/business-stakeholders";
+    private static final String LEGAL_ENTITY_ENDPOINT =
+            ACCOUNT_METADATA_WEBAPP_BASE_URL + "/legal-entity";
 
     private static final String BASIC_AUTH = Base64.getEncoder().encodeToString("user:pass".getBytes());
 
-    /**
-    * Verifies blocked joint accounts are extracted when the metadata service returns a valid response.
-    */
+    // ---- helpers ----
+
+    private static CloseableHttpResponse mockResponse(int statusCode, String body) throws Exception {
+        CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
+        StatusLine statusLine = Mockito.mock(StatusLine.class);
+
+        Mockito.when(statusLine.getStatusCode()).thenReturn(statusCode);
+        Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+        Mockito.when(response.getEntity()).thenReturn(new StringEntity(body, StandardCharsets.UTF_8));
+        return response;
+    }
+
+    private static CloseableHttpClient mockClientWithResponse(int statusCode, String body) throws Exception {
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        CloseableHttpResponse response = mockResponse(statusCode, body);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class))).thenReturn(response);
+        return client;
+    }
+
+    // ---- fetchBlockedJointAccountsFromService tests ----
+
     @Test
     public void testFetchBlockedAccountsFromServiceSuccess() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("["
+        CloseableHttpClient client = mockClientWithResponse(200, "["
                 + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"},"
                 + "{\"accountId\":\"acc-2\",\"disclosureOption\":\"pre-approval\"},"
                 + "{\"accountId\":\"acc-3\",\"disclosureOption\":\"no-sharing\"}"
                 + "]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -79,10 +94,10 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.contains("acc-1"));
         Assert.assertTrue(blocked.contains("acc-3"));
 
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        Mockito.verify(client).send(requestCaptor.capture(), Mockito.<HttpResponse.BodyHandler<String>>any());
-        Assert.assertTrue(requestCaptor.getValue().uri().toString().contains("accountIds="));
-        Assert.assertEquals(requestCaptor.getValue().headers().firstValue("Authorization").orElse(null),
+        ArgumentCaptor<HttpGet> requestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+        Mockito.verify(client).execute(requestCaptor.capture());
+        Assert.assertTrue(requestCaptor.getValue().getURI().toString().contains("accountIds="));
+        Assert.assertEquals(requestCaptor.getValue().getFirstHeader("Authorization").getValue(),
                 "Basic " + BASIC_AUTH);
     }
 
@@ -91,15 +106,7 @@ public class CDSAccountValidationUtilsTest {
     */
     @Test
     public void testFetchBlockedAccountsFromServiceNon200() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(500);
-        Mockito.when(response.body()).thenReturn("[]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(500, "[]"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -113,12 +120,10 @@ public class CDSAccountValidationUtilsTest {
     */
     @Test
     public void testFetchBlockedAccountsFromServiceIoError() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
                 .thenThrow(new IOException("Connection failed"));
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -132,20 +137,10 @@ public class CDSAccountValidationUtilsTest {
     */
     @Test
     public void testFetchBlockedAccountsWithAuthHeader() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn(new JSONArray()
-                .put(new JSONObject()
-                        .put(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, "acc-1")
-                        .put(CDSAccountValidationConstants.DISCLOSURE_OPTION_TAG,
-                                CDSAccountValidationConstants.DOMS_STATUS_NO_SHARING))
-                .toString());
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CloseableHttpClient client = mockClientWithResponse(200, "["
+                + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"}"
+                + "]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -156,9 +151,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertEquals(blocked.size(), 1);
         Assert.assertTrue(blocked.contains("acc-1"));
 
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        Mockito.verify(client).send(requestCaptor.capture(), Mockito.<HttpResponse.BodyHandler<String>>any());
-        Assert.assertEquals(requestCaptor.getValue().headers().firstValue("Authorization").orElse(null),
+        ArgumentCaptor<HttpGet> requestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+        Mockito.verify(client).execute(requestCaptor.capture());
+        Assert.assertEquals(requestCaptor.getValue().getFirstHeader("Authorization").getValue(),
                 "Basic " + BASIC_AUTH);
     }
 
@@ -167,20 +162,10 @@ public class CDSAccountValidationUtilsTest {
     */
     @Test
     public void testFetchBlockedAccountsSuccessIncludesRequiredAuthHeader() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn(new JSONArray()
-                .put(new JSONObject()
-                        .put(CDSAccountValidationConstants.CDS_ACCOUNT_ID_TAG, "acc-2")
-                        .put(CDSAccountValidationConstants.DISCLOSURE_OPTION_TAG,
-                                CDSAccountValidationConstants.DOMS_STATUS_NO_SHARING))
-                .toString());
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CloseableHttpClient client = mockClientWithResponse(200, "["
+                + "{\"accountId\":\"acc-2\",\"disclosureOption\":\"no-sharing\"}"
+                + "]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-2");
@@ -191,9 +176,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertEquals(blocked.size(), 1);
         Assert.assertTrue(blocked.contains("acc-2"));
 
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        Mockito.verify(client).send(requestCaptor.capture(), Mockito.<HttpResponse.BodyHandler<String>>any());
-        Assert.assertEquals(requestCaptor.getValue().headers().firstValue("Authorization").orElse(null),
+        ArgumentCaptor<HttpGet> requestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+        Mockito.verify(client).execute(requestCaptor.capture());
+        Assert.assertEquals(requestCaptor.getValue().getFirstHeader("Authorization").getValue(),
                 "Basic " + BASIC_AUTH);
     }
 
@@ -218,19 +203,12 @@ public class CDSAccountValidationUtilsTest {
      */
     @Test
     public void testFetchBlockedAccountsSkipsInvalidRowsAndBlankAccountId() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("["
+        CloseableHttpClient client = mockClientWithResponse(200, "["
                 + "\"invalid\","
                 + "{\"disclosureOption\":\"no-sharing\"},"
                 + "{\"accountId\":\"acc-5\",\"disclosureOption\":\"no-sharing\"}"
                 + "]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-5");
@@ -246,38 +224,8 @@ public class CDSAccountValidationUtilsTest {
      * Verifies interrupted DOMS requests raise a validation exception and preserve interrupt status.
      */
     @Test
-    public void testFetchBlockedAccountsFromServiceInterruptedError() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenThrow(new InterruptedException("interrupted"));
-
-        CDSAccountValidationUtils.setHttpClient(client);
-
-        Set<String> accounts = new HashSet<>();
-        accounts.add("acc-1");
-
-        Assert.expectThrows(CDSAccountValidationException.class,
-                () -> CDSAccountValidationUtils.fetchBlockedJointAccountsFromService(
-                        accounts, DOMS_ENDPOINT, BASIC_AUTH));
-        Assert.assertTrue(Thread.currentThread().isInterrupted());
-        Thread.interrupted();
-    }
-
-    /**
-     * Verifies malformed DOMS payloads trigger a validation exception.
-     */
-    @Test
     public void testFetchBlockedAccountsFromServiceMalformedResponse() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("{not-an-array");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -289,23 +237,13 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchBlockedSecondaryAccountsFromService tests ----
 
-    /**
-     * Verifies inactive secondary-account instructions are marked as blocked.
-     */
     @Test
     public void testFetchBlockedSecondaryAccountsSuccess() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("["
+        CloseableHttpClient client = mockClientWithResponse(200, "["
                 + "{\"accountId\":\"acc-1\",\"secondaryAccountInstructionStatus\":\"inactive\"},"
                 + "{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"active\"}"
                 + "]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -320,19 +258,11 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-     * Verifies non-200 responses from the secondary-account endpoint raise a validation exception.
+     * Verifies malformed DOMS payloads trigger a validation exception.
      */
     @Test
     public void testFetchBlockedSecondaryAccountsNon200() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(503);
-        Mockito.when(response.body()).thenReturn("[]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(503, "[]"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -342,17 +272,12 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
-    /**
-     * Verifies I/O failures from the secondary-account endpoint are wrapped as validation exceptions.
-     */
     @Test
     public void testFetchBlockedSecondaryAccountsIoError() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
                 .thenThrow(new IOException("Connection refused"));
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -362,42 +287,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
-    /**
-     * Verifies interrupted secondary-account requests raise a validation exception and preserve interrupt status.
-     */
-    @Test
-    public void testFetchBlockedSecondaryAccountsInterruptedError() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenThrow(new InterruptedException("interrupted"));
-
-        CDSAccountValidationUtils.setHttpClient(client);
-
-        Set<String> accounts = new HashSet<>();
-        accounts.add("acc-1");
-
-        Assert.expectThrows(CDSAccountValidationException.class,
-                () -> CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
-                        accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
-        Assert.assertTrue(Thread.currentThread().isInterrupted());
-        Thread.interrupted();
-    }
-
-    /**
-     * Verifies malformed secondary-account payloads trigger a validation exception.
-     */
     @Test
     public void testFetchBlockedSecondaryAccountsMalformedResponse() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("{not-an-array");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -407,9 +299,6 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
-    /**
-     * Verifies empty or null account sets return an empty secondary blocked-account result.
-     */
     @Test
     public void testFetchBlockedSecondaryAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
@@ -423,20 +312,26 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
-    /**
-     * Verifies both accountIds and userId query parameters are included for secondary-account requests.
-     */
+    @Test
+    public void testFetchBlockedSecondaryAccountsWithBlankUserId() throws Exception {
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+        Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                accounts, SECONDARY_ACCOUNTS_ENDPOINT, "", BASIC_AUTH);
+        Assert.assertNotNull(blockedForBlank);
+        Assert.assertTrue(blockedForBlank.isEmpty());
+
+        Assert.expectThrows(NullPointerException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
+                        accounts, SECONDARY_ACCOUNTS_ENDPOINT, null, BASIC_AUTH));
+    }
+
     @Test
     public void testFetchBlockedSecondaryAccountsIncludesUserIdInRequest() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("[]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CloseableHttpClient client = mockClientWithResponse(200, "[]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -444,34 +339,24 @@ public class CDSAccountValidationUtilsTest {
         CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
                 accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-99", BASIC_AUTH);
 
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        Mockito.verify(client).send(requestCaptor.capture(), Mockito.<HttpResponse.BodyHandler<String>>any());
-        String requestUri = requestCaptor.getValue().uri().toString();
+        ArgumentCaptor<HttpGet> requestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+        Mockito.verify(client).execute(requestCaptor.capture());
+        String requestUri = requestCaptor.getValue().getURI().toString();
         Assert.assertTrue(requestUri.contains("accountIds="));
         Assert.assertTrue(requestUri.contains("userId="));
-        Assert.assertEquals(requestCaptor.getValue().headers().firstValue("Authorization").orElse(null),
+        Assert.assertEquals(requestCaptor.getValue().getFirstHeader("Authorization").getValue(),
                 "Basic " + BASIC_AUTH);
     }
 
-    /**
-     * Verifies invalid rows and active instructions are skipped while inactive rows are blocked.
-     */
     @Test
     public void testFetchBlockedSecondaryAccountsSkipsInvalidAndNonInactiveRows() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> response = Mockito.mock(HttpResponse.class);
-
-        Mockito.when(response.statusCode()).thenReturn(200);
-        Mockito.when(response.body()).thenReturn("["
+        CloseableHttpClient client = mockClientWithResponse(200, "["
                 + "\"invalid-string-entry\","
                 + "{\"secondaryAccountInstructionStatus\":\"inactive\"},"
                 + "{\"accountId\":\"acc-active\",\"secondaryAccountInstructionStatus\":\"active\"},"
                 + "{\"accountId\":\"acc-inactive\",\"secondaryAccountInstructionStatus\":\"inactive\"}"
                 + "]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(response);
-
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-active");
@@ -488,13 +373,70 @@ public class CDSAccountValidationUtilsTest {
     // ---- fetchBlockedBusinessAccountsFromService tests ----
 
     @Test
-    public void testFetchBlockedBusinessAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
-        String businessStakeholdersEndpoint = ACCOUNT_METADATA_WEBAPP_BASE_URL + "/business-stakeholders";
+    public void testFetchBlockedBusinessAccountsSuccess() throws Exception {
+        CloseableHttpClient client = mockClientWithResponse(200, "["
+                + "{\"accountId\":\"acc-1\",\"permission\":\"VIEW\"},"
+                + "{\"accountId\":\"acc-2\",\"permission\":\"AUTHORIZE\"}"
+                + "]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        accounts.add("acc-2");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH);
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-1"));
+        Assert.assertFalse(blocked.contains("acc-2"));
+    }
+
+    @Test
+    public void testFetchBlockedBusinessAccountsNon200() throws Exception {
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(503, "[]"));
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                        accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH));
+    }
+
+    @Test
+    public void testFetchBlockedBusinessAccountsIoError() throws Exception {
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenThrow(new IOException("Connection refused"));
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                        accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH));
+    }
+
+    @Test
+    public void testFetchBlockedBusinessAccountsMalformedResponse() throws Exception {
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                        accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH));
+    }
+
+    @Test
+    public void testFetchBlockedBusinessAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
-                Collections.emptySet(), businessStakeholdersEndpoint, "user-1", BASIC_AUTH);
+                Collections.emptySet(), BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH);
         Set<String> blockedForNull = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
-                null, businessStakeholdersEndpoint, "user-1", BASIC_AUTH);
+                null, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH);
 
         Assert.assertNotNull(blockedForEmpty);
         Assert.assertNotNull(blockedForNull);
@@ -502,59 +444,93 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
+        @Test
+        public void testFetchBlockedBusinessAccountsWithBlankUserId() throws Exception {
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+                CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+                Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                                accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "", BASIC_AUTH);
+                Assert.assertNotNull(blockedForBlank);
+                Assert.assertTrue(blockedForBlank.isEmpty());
+
+        Assert.expectThrows(NullPointerException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                        accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, null, BASIC_AUTH));
+    }
+
     @Test
-    public void testFetchBlockedBusinessAccountsWithBlankBasicAuth() {
-        String businessStakeholdersEndpoint = ACCOUNT_METADATA_WEBAPP_BASE_URL + "/business-stakeholders";
+    public void testFetchBlockedBusinessAccountsIncludesUserIdInRequest() throws Exception {
+        CloseableHttpClient client = mockClientWithResponse(200, "[]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
 
-        Assert.expectThrows(CDSAccountValidationException.class,
-                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
-                        accounts, businessStakeholdersEndpoint, "user-1", ""));
-        Assert.expectThrows(CDSAccountValidationException.class,
-                () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
-                        accounts, businessStakeholdersEndpoint, "user-1", null));
+        CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-99", BASIC_AUTH);
+
+        ArgumentCaptor<HttpGet> requestCaptor = ArgumentCaptor.forClass(HttpGet.class);
+        Mockito.verify(client).execute(requestCaptor.capture());
+        String requestUri = requestCaptor.getValue().getURI().toString();
+        Assert.assertTrue(requestUri.contains("accountIds="));
+        Assert.assertTrue(requestUri.contains("userId="));
+        Assert.assertEquals(requestCaptor.getValue().getFirstHeader("Authorization").getValue(),
+                "Basic " + BASIC_AUTH);
+    }
+
+    @Test
+    public void testFetchBlockedBusinessAccountsSkipsInvalidAndAuthorizeRows() throws Exception {
+        CloseableHttpClient client = mockClientWithResponse(200, "["
+                + "\"invalid-entry\","
+                + "{\"permission\":\"VIEW\"},"
+                + "{\"accountId\":\"acc-auth\",\"permission\":\"AUTHORIZE\"},"
+                + "{\"accountId\":\"acc-view\",\"permission\":\"VIEW\"}"
+                + "]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-auth");
+        accounts.add("acc-view");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH);
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-view"));
+        Assert.assertFalse(blocked.contains("acc-auth"));
     }
 
     // ---- fetchAllBlockedAccounts tests ----
 
-    /**
-     * Verifies blocked-account results from DOMS and secondary-account checks are merged.
-     */
     @Test
     public void testFetchAllBlockedAccountsWithEmptyInput() throws CDSAccountValidationException {
         Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                Collections.emptySet(), ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH);
+                Collections.emptySet(), ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH, null);
         Assert.assertNotNull(blocked);
         Assert.assertTrue(blocked.isEmpty());
     }
 
     @Test
     public void testFetchAllBlockedAccountsCombinesResults() throws Exception {
-        HttpClient client = Mockito.mock(HttpClient.class);
-        HttpResponse<String> disclosureResponse = Mockito.mock(HttpResponse.class);
-        HttpResponse<String> secondaryResponse = Mockito.mock(HttpResponse.class);
-        HttpResponse<String> businessResponse = Mockito.mock(HttpResponse.class);
+        // Pre-create all responses before the Mockito.when chain to avoid UnfinishedStubbingException
+        // (mockResponse internally calls Mockito.when, which must not happen mid-chain).
+        CloseableHttpResponse disclosureResp = mockResponse(200,
+                "[{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"}]");
+        CloseableHttpResponse secondaryResp = mockResponse(200,
+                "[{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"inactive\"}]");
+        CloseableHttpResponse businessResp = mockResponse(200,
+                "[{\"accountId\":\"acc-3\",\"permission\":\"VIEW\"}]");
 
-        Mockito.when(disclosureResponse.statusCode()).thenReturn(200);
-        Mockito.when(disclosureResponse.body()).thenReturn("["
-                + "{\"accountId\":\"acc-1\",\"disclosureOption\":\"no-sharing\"}"
-                + "]");
-        Mockito.when(secondaryResponse.statusCode()).thenReturn(200);
-        Mockito.when(secondaryResponse.body()).thenReturn("["
-                + "{\"accountId\":\"acc-2\",\"secondaryAccountInstructionStatus\":\"inactive\"}"
-                + "]");
-        Mockito.when(businessResponse.statusCode()).thenReturn(200);
-        Mockito.when(businessResponse.body()).thenReturn("["
-                + "{\"accountId\":\"acc-3\",\"permission\":\"VIEW\"}"
-                + "]");
-        Mockito.when(client.send(Mockito.any(HttpRequest.class), Mockito.<HttpResponse.BodyHandler<String>>any()))
-                .thenReturn(disclosureResponse)
-                .thenReturn(secondaryResponse)
-                .thenReturn(businessResponse);
+        // disclosure → secondary → business; legal entity is skipped because clientId is null
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenReturn(disclosureResp)
+                .thenReturn(secondaryResp)
+                .thenReturn(businessResp);
 
-        CDSAccountValidationUtils.setHttpClient(client);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
 
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
@@ -563,7 +539,7 @@ public class CDSAccountValidationUtilsTest {
         accounts.add("acc-4");
 
         Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
-                accounts, ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH);
+                accounts, ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH, null);
 
         Assert.assertEquals(blocked.size(), 3);
         Assert.assertTrue(blocked.contains("acc-1"));
@@ -585,8 +561,208 @@ public class CDSAccountValidationUtilsTest {
             Assert.assertEquals(signedJwt.split("\\.").length, 3);
         } catch (ExceptionInInitializerError | NoClassDefFoundError | NullPointerException |
                  com.nimbusds.jose.JOSEException e) {
-            // In unit-test runtime, KeyStoreUtils may fail to initialize due missing server config.
             Assert.assertTrue(true);
         }
+    }
+
+    // ---- CDSAccountValidationException constructor tests ----
+
+    @Test
+    public void testCDSAccountValidationExceptionStringConstructor() {
+        CDSAccountValidationException ex = new CDSAccountValidationException("test-message");
+        Assert.assertEquals(ex.getMessage(), "test-message");
+        Assert.assertNull(ex.getCause());
+    }
+
+    @Test
+    public void testCDSAccountValidationExceptionStringThrowableConstructor() {
+        Throwable cause = new RuntimeException("root-cause");
+        CDSAccountValidationException ex = new CDSAccountValidationException("test-message", cause);
+        Assert.assertEquals(ex.getMessage(), "test-message");
+        Assert.assertEquals(ex.getCause(), cause);
+    }
+
+    // ---- fetchBlockedLegalEntityAccountsFromService tests ----
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsWithNullAccountIds() throws CDSAccountValidationException {
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                null, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1");
+        Assert.assertNotNull(blocked);
+        Assert.assertTrue(blocked.isEmpty());
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsWithEmptyAccountIds() throws CDSAccountValidationException {
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                Collections.emptySet(), LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1");
+        Assert.assertNotNull(blocked);
+        Assert.assertTrue(blocked.isEmpty());
+    }
+
+        @Test
+        public void testFetchBlockedLegalEntityAccountsWithBlankUserId() throws Exception {
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+
+                CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+                Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                                accounts, LEGAL_ENTITY_ENDPOINT, "", BASIC_AUTH, "client-1");
+                Assert.assertNotNull(blockedForBlank);
+                Assert.assertTrue(blockedForBlank.isEmpty());
+
+        Assert.expectThrows(NullPointerException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                        accounts, LEGAL_ENTITY_ENDPOINT, null, BASIC_AUTH, "client-1"));
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsWithNullClientId() throws CDSAccountValidationException {
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, null);
+        Assert.assertNotNull(blocked);
+        Assert.assertTrue(blocked.isEmpty());
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsWhenLegalEntityIdBlank() throws Exception {
+        CloseableHttpClient client = mockClientWithResponse(200, "[]");
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1");
+
+        Assert.assertNotNull(blocked);
+        Assert.assertTrue(blocked.isEmpty());
+        Mockito.verify(client, Mockito.times(1)).execute(Mockito.any(HttpGet.class));
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsSuccess() throws Exception {
+        // null element in array covers the sharingItem == null branch
+        String leResponse = "[null,"
+                + "{\"accountID\":\"acc-1\",\"legalEntitySharingStatus\":\"blocked\"},"
+                + "{\"accountID\":\"acc-2\",\"legalEntitySharingStatus\":\"allowed\"}"
+                + "]";
+
+        CloseableHttpResponse leResp = mockResponse(200, leResponse);
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenReturn(leResp);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        accounts.add("acc-2");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1");
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-1"));
+        Assert.assertFalse(blocked.contains("acc-2"));
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsFallbackKeys() throws Exception {
+        // Tests accountId (camelCase) fallback key path.
+        String leResponse = "["
+                + "{\"accountId\":\"acc-camel\",\"legalEntitySharingStatus\":\"blocked\"}"
+                + "]";
+
+        CloseableHttpResponse leResp = mockResponse(200, leResponse);
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenReturn(leResp);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-camel");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1");
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-camel"));
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsNon200() throws Exception {
+        CloseableHttpResponse leResp = mockResponse(503, "[]");
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenReturn(leResp);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                        accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1"));
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsIoError() throws Exception {
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenThrow(new IOException("Connection refused"));
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                        accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1"));
+    }
+
+    @Test
+    public void testFetchBlockedLegalEntityAccountsMalformedResponse() throws Exception {
+        CloseableHttpResponse leResp = mockResponse(200, "{not-an-array");
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenReturn(leResp);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        Assert.expectThrows(CDSAccountValidationException.class,
+                () -> CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                        accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1"));
+    }
+
+    // ---- fetchAllBlockedAccounts with clientId (exercises legal entity path) ----
+
+    @Test
+    public void testFetchAllBlockedAccountsWithClientId() throws Exception {
+        String leBody = "[{\"accountID\":\"acc-1\",\"legalEntitySharingStatus\":\"blocked\"}]";
+
+        CloseableHttpResponse disclosureResp = mockResponse(200, "[]");
+        CloseableHttpResponse secondaryResp = mockResponse(200, "[]");
+        CloseableHttpResponse businessResp = mockResponse(200, "[]");
+        CloseableHttpResponse leResp = mockResponse(200, leBody);
+
+        CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(client.execute(Mockito.any(HttpGet.class)))
+                .thenReturn(disclosureResp)
+                .thenReturn(secondaryResp)
+                .thenReturn(businessResp)
+                .thenReturn(leResp);
+        CDSAccountValidationUtils.setApacheHttpClient(client);
+
+        Set<String> accounts = new HashSet<>();
+        accounts.add("acc-1");
+        accounts.add("acc-2");
+
+        Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
+                accounts, ACCOUNT_METADATA_WEBAPP_BASE_URL, "user-1", BASIC_AUTH, "client-1");
+
+        Assert.assertEquals(blocked.size(), 1);
+        Assert.assertTrue(blocked.contains("acc-1"));
+        Assert.assertFalse(blocked.contains("acc-2"));
+        Mockito.verify(client, Mockito.times(4)).execute(Mockito.any(HttpGet.class));
     }
 }

--- a/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
+++ b/components/policies/cds-account-validation-policy/src/test/java/org/wso2/openbanking/consumerdatastandards/au/policy/utils/CDSAccountValidationUtilsTest.java
@@ -54,6 +54,14 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- helpers ----
 
+    /**
+     * Creates a mocked CloseableHttpResponse with the specified status code and response body.
+     *
+     * @param statusCode the HTTP status code for the response
+     * @param body the response body as a string
+     * @return a mocked CloseableHttpResponse
+     * @throws Exception if mock creation fails
+     */
     private static CloseableHttpResponse mockResponse(int statusCode, String body) throws Exception {
         CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
         StatusLine statusLine = Mockito.mock(StatusLine.class);
@@ -64,6 +72,14 @@ public class CDSAccountValidationUtilsTest {
         return response;
     }
 
+    /**
+     * Creates a mocked CloseableHttpClient that returns a response with the specified status code and body.
+     *
+     * @param statusCode the HTTP status code for the response
+     * @param body the response body as a string
+     * @return a mocked CloseableHttpClient configured to return the specified response
+     * @throws Exception if mock creation fails
+     */
     private static CloseableHttpClient mockClientWithResponse(int statusCode, String body) throws Exception {
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
         CloseableHttpResponse response = mockResponse(statusCode, body);
@@ -73,6 +89,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchBlockedJointAccountsFromService tests ----
 
+    /**
+     * Verifies successful DOMS response with multiple accounts returns the correct blocked accounts.
+     */
     @Test
     public void testFetchBlockedAccountsFromServiceSuccess() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -102,8 +121,8 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-    * Verifies a non-200 DOMS response is surfaced as a validation exception.
-    */
+     * Verifies a non-200 DOMS response is surfaced as a validation exception.
+     */
     @Test
     public void testFetchBlockedAccountsFromServiceNon200() throws Exception {
         CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(500, "[]"));
@@ -116,8 +135,8 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-    * Verifies I/O failures from the DOMS service call are wrapped as validation exceptions.
-    */
+     * Verifies I/O failures from the DOMS service call are wrapped as validation exceptions.
+     */
     @Test
     public void testFetchBlockedAccountsFromServiceIoError() throws Exception {
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
@@ -133,8 +152,8 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-    * Verifies Basic authorization is sent when fetching blocked joint accounts.
-    */
+     * Verifies Basic authorization is sent when fetching blocked joint accounts.
+     */
     @Test
     public void testFetchBlockedAccountsWithAuthHeader() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -158,8 +177,8 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-    * Verifies successful DOMS calls include the required authorization header.
-    */
+     * Verifies successful DOMS calls include the required authorization header.
+     */
     @Test
     public void testFetchBlockedAccountsSuccessIncludesRequiredAuthHeader() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -183,8 +202,8 @@ public class CDSAccountValidationUtilsTest {
     }
 
     /**
-    * Verifies empty or null account sets return an empty blocked-account result.
-    */
+     * Verifies empty or null account sets return an empty blocked-account result.
+     */
     @Test
     public void testFetchBlockedAccountsFromServiceWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedJointAccountsFromService(
@@ -237,6 +256,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchBlockedSecondaryAccountsFromService tests ----
 
+    /**
+     * Verifies successful secondary accounts response returns inactive accounts as blocked.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsSuccess() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -272,6 +294,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies I/O failures from the secondary accounts service call are wrapped as validation exceptions.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsIoError() throws Exception {
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
@@ -287,6 +312,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies malformed secondary accounts JSON responses raise a validation exception.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsMalformedResponse() throws Exception {
         CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
@@ -299,6 +327,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies empty or null account sets return an empty blocked-account result for secondary accounts.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedSecondaryAccountsFromService(
@@ -312,6 +343,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
+    /**
+     * Verifies blank user ID returns empty results while null user ID raises a NullPointerException.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsWithBlankUserId() throws Exception {
         Set<String> accounts = new HashSet<>();
@@ -328,6 +362,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, SECONDARY_ACCOUNTS_ENDPOINT, null, BASIC_AUTH));
     }
 
+    /**
+     * Verifies the secondary accounts request includes both account IDs and user ID parameters.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsIncludesUserIdInRequest() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "[]");
@@ -348,6 +385,9 @@ public class CDSAccountValidationUtilsTest {
                 "Basic " + BASIC_AUTH);
     }
 
+    /**
+     * Verifies malformed rows and active accounts are skipped while inactive accounts are returned as blocked.
+     */
     @Test
     public void testFetchBlockedSecondaryAccountsSkipsInvalidAndNonInactiveRows() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -372,6 +412,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchBlockedBusinessAccountsFromService tests ----
 
+    /**
+     * Verifies successful business stakeholders response returns VIEW permission accounts as blocked.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsSuccess() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -392,6 +435,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertFalse(blocked.contains("acc-2"));
     }
 
+    /**
+     * Verifies a non-200 business stakeholders response triggers a validation exception.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsNon200() throws Exception {
         CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(503, "[]"));
@@ -404,6 +450,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies I/O failures from the business stakeholders service call are wrapped as validation exceptions.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsIoError() throws Exception {
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
@@ -419,6 +468,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies malformed business stakeholders JSON responses raise a validation exception.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsMalformedResponse() throws Exception {
         CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "{not-an-array"));
@@ -431,6 +483,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "user-1", BASIC_AUTH));
     }
 
+    /**
+     * Verifies empty or null account sets return an empty blocked-account result for business accounts.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsWithEmptyOrNullAccountIds() throws CDSAccountValidationException {
         Set<String> blockedForEmpty = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
@@ -444,22 +499,28 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blockedForNull.isEmpty());
     }
 
-        @Test
-        public void testFetchBlockedBusinessAccountsWithBlankUserId() throws Exception {
+    /**
+     * Verifies blank user ID returns empty results while null user ID raises a NullPointerException for business accounts.
+     */
+    @Test
+    public void testFetchBlockedBusinessAccountsWithBlankUserId() throws Exception {
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
 
-                CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
-                Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
-                                accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "", BASIC_AUTH);
-                Assert.assertNotNull(blockedForBlank);
-                Assert.assertTrue(blockedForBlank.isEmpty());
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+        Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
+                accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, "", BASIC_AUTH);
+        Assert.assertNotNull(blockedForBlank);
+        Assert.assertTrue(blockedForBlank.isEmpty());
 
         Assert.expectThrows(NullPointerException.class,
                 () -> CDSAccountValidationUtils.fetchBlockedBusinessAccountsFromService(
                         accounts, BUSINESS_STAKEHOLDERS_ENDPOINT, null, BASIC_AUTH));
     }
 
+    /**
+     * Verifies the business stakeholders request includes both account IDs and user ID parameters.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsIncludesUserIdInRequest() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "[]");
@@ -480,6 +541,9 @@ public class CDSAccountValidationUtilsTest {
                 "Basic " + BASIC_AUTH);
     }
 
+    /**
+     * Verifies malformed rows and AUTHORIZE permission accounts are skipped while VIEW permission accounts are returned as blocked.
+     */
     @Test
     public void testFetchBlockedBusinessAccountsSkipsInvalidAndAuthorizeRows() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "["
@@ -504,6 +568,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchAllBlockedAccounts tests ----
 
+    /**
+     * Verifies empty input account set returns an empty blocked accounts result.
+     */
     @Test
     public void testFetchAllBlockedAccountsWithEmptyInput() throws CDSAccountValidationException {
         Set<String> blocked = CDSAccountValidationUtils.fetchAllBlockedAccounts(
@@ -512,6 +579,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.isEmpty());
     }
 
+    /**
+     * Verifies fetchAllBlockedAccounts combines results from disclosure options, secondary, and business endpoints.
+     */
     @Test
     public void testFetchAllBlockedAccountsCombinesResults() throws Exception {
         // Pre-create all responses before the Mockito.when chain to avoid UnfinishedStubbingException
@@ -567,6 +637,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- CDSAccountValidationException constructor tests ----
 
+    /**
+     * Verifies CDSAccountValidationException string constructor sets the message correctly.
+     */
     @Test
     public void testCDSAccountValidationExceptionStringConstructor() {
         CDSAccountValidationException ex = new CDSAccountValidationException("test-message");
@@ -574,6 +647,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertNull(ex.getCause());
     }
 
+    /**
+     * Verifies CDSAccountValidationException string-throwable constructor sets message and cause correctly.
+     */
     @Test
     public void testCDSAccountValidationExceptionStringThrowableConstructor() {
         Throwable cause = new RuntimeException("root-cause");
@@ -584,6 +660,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchBlockedLegalEntityAccountsFromService tests ----
 
+    /**
+     * Verifies null account IDs return an empty blocked accounts result for legal entity.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsWithNullAccountIds() throws CDSAccountValidationException {
         Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
@@ -592,6 +671,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.isEmpty());
     }
 
+    /**
+     * Verifies empty account IDs return an empty blocked accounts result for legal entity.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsWithEmptyAccountIds() throws CDSAccountValidationException {
         Set<String> blocked = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
@@ -600,22 +682,28 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.isEmpty());
     }
 
-        @Test
-        public void testFetchBlockedLegalEntityAccountsWithBlankUserId() throws Exception {
+    /**
+     * Verifies blank user ID returns empty results while null user ID raises a NullPointerException for legal entity.
+     */
+    @Test
+    public void testFetchBlockedLegalEntityAccountsWithBlankUserId() throws Exception {
         Set<String> accounts = new HashSet<>();
         accounts.add("acc-1");
 
-                CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
-                Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
-                                accounts, LEGAL_ENTITY_ENDPOINT, "", BASIC_AUTH, "client-1");
-                Assert.assertNotNull(blockedForBlank);
-                Assert.assertTrue(blockedForBlank.isEmpty());
+        CDSAccountValidationUtils.setApacheHttpClient(mockClientWithResponse(200, "[]"));
+        Set<String> blockedForBlank = CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
+                accounts, LEGAL_ENTITY_ENDPOINT, "", BASIC_AUTH, "client-1");
+        Assert.assertNotNull(blockedForBlank);
+        Assert.assertTrue(blockedForBlank.isEmpty());
 
         Assert.expectThrows(NullPointerException.class,
                 () -> CDSAccountValidationUtils.fetchBlockedLegalEntityAccountsFromService(
                         accounts, LEGAL_ENTITY_ENDPOINT, null, BASIC_AUTH, "client-1"));
     }
 
+    /**
+     * Verifies null client ID returns empty blocked accounts result for legal entity.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsWithNullClientId() throws CDSAccountValidationException {
         Set<String> accounts = new HashSet<>();
@@ -626,6 +714,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.isEmpty());
     }
 
+    /**
+     * Verifies the legal entity endpoint is called when client ID is provided.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsWhenLegalEntityIdBlank() throws Exception {
         CloseableHttpClient client = mockClientWithResponse(200, "[]");
@@ -641,6 +732,9 @@ public class CDSAccountValidationUtilsTest {
         Mockito.verify(client, Mockito.times(1)).execute(Mockito.any(HttpGet.class));
     }
 
+    /**
+     * Verifies successful legal entity response returns blocked accounts with camelCase accountID field.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsSuccess() throws Exception {
         // null element in array covers the sharingItem == null branch
@@ -667,6 +761,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertFalse(blocked.contains("acc-2"));
     }
 
+    /**
+     * Verifies legal entity response parsing supports camelCase accountId fallback key.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsFallbackKeys() throws Exception {
         // Tests accountId (camelCase) fallback key path.
@@ -690,6 +787,9 @@ public class CDSAccountValidationUtilsTest {
         Assert.assertTrue(blocked.contains("acc-camel"));
     }
 
+    /**
+     * Verifies a non-200 legal entity response triggers a validation exception.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsNon200() throws Exception {
         CloseableHttpResponse leResp = mockResponse(503, "[]");
@@ -705,6 +805,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1"));
     }
 
+    /**
+     * Verifies I/O failures from the legal entity service call are wrapped as validation exceptions.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsIoError() throws Exception {
         CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
@@ -719,6 +822,9 @@ public class CDSAccountValidationUtilsTest {
                         accounts, LEGAL_ENTITY_ENDPOINT, "user-1", BASIC_AUTH, "client-1"));
     }
 
+    /**
+     * Verifies malformed legal entity JSON responses raise a validation exception.
+     */
     @Test
     public void testFetchBlockedLegalEntityAccountsMalformedResponse() throws Exception {
         CloseableHttpResponse leResp = mockResponse(200, "{not-an-array");
@@ -736,6 +842,9 @@ public class CDSAccountValidationUtilsTest {
 
     // ---- fetchAllBlockedAccounts with clientId (exercises legal entity path) ----
 
+    /**
+     * Verifies fetchAllBlockedAccounts with clientId includes legal entity blocking logic.
+     */
     @Test
     public void testFetchAllBlockedAccountsWithClientId() throws Exception {
         String leBody = "[{\"accountID\":\"acc-1\",\"legalEntitySharingStatus\":\"blocked\"}]";


### PR DESCRIPTION
## Add CDS Policy to Filter Ceasing secondary user sharing blocked Accounts from Account Resource call

> This pull request introduces a CDS policy enhancement to support the Ceasing Secondary User Sharing feature in CDS Toolkit 2.0. The implementation ensures that account data is not exposed to TPPs associated with a blocked legal entity during account resource API responses. Once a legal entity is blocked, all underlying TPPs are restricted from accessing shared data, effectively ceasing data sharing at the source. This update strengthens consent enforcement and data governance by preventing further data disclosure to unauthorized parties and ensuring compliance with CDS requirements through consistent, legal entity–level access control.

------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?