### PR TITLE
fix: fixed psu configurations, customer langugage tests

### DIFF
--- a/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/bnr/ConsentAuthFlowValidationTests.groovy
+++ b/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/bnr/ConsentAuthFlowValidationTests.groovy
@@ -40,7 +40,7 @@ import java.nio.charset.Charset
  *
  * PSU assignments (fixed sharable accounts payload — NR membership is static):
  *   PSU 3 (nominatedUser1@wso2.com) — NR of Org A and both Org B accounts
- *   PSU 0 (psu@gold.com)           — not in any NR list, sees only individual accounts
+ *   PSU 1 (psu@gold.com)           — not in any NR list, sees only individual accounts
  */
 class ConsentAuthFlowValidationTests extends AUTest {
 
@@ -86,6 +86,7 @@ class ConsentAuthFlowValidationTests extends AUTest {
     @Test
     void "CDS-477_Verify Profile Selection is displayed in Auth Flow when the configuration is enabled"() {
 
+        auConfiguration.setPsuNumber(0)
         response = auAuthorisationBuilder.doPushAuthorisationRequest(scopes, AUConstants.DEFAULT_SHARING_DURATION,
                 true, "")
         requestUri = AUTestUtil.parseResponseBody(response, AUConstants.REQUEST_URI)
@@ -108,12 +109,11 @@ class ConsentAuthFlowValidationTests extends AUTest {
                 .execute()
     }
 
-    // TODO: Enable after implementing customer language rendering for individual and business consumer profiles
-      @Test(priority = 1, enabled = false)
+    @Test(priority = 1)
     void "CDS-543_Verify customer language in consent page for individual consumer"() {
 
         auConfiguration.setPsuNumber(0)
-        List<AUAccountScope> scopes = [AUAccountScope.BANK_CUSTOMER_BASIC_READ]
+        List<AUAccountScope> scopes = [AUAccountScope.BANK_CUSTOMER_DETAIL_READ]
 
         response = auAuthorisationBuilder.doPushAuthorisationRequest(scopes, AUConstants.DEFAULT_SHARING_DURATION,
                 true, "")
@@ -129,13 +129,24 @@ class ConsentAuthFlowValidationTests extends AUTest {
                         authWebDriver.selectOption(AUPageObjects.INDIVIDUAL_PROFILE_SELECTION)
                         authWebDriver.clickButtonXpath(AUPageObjects.PROFILE_SELECTION_NEXT_BUTTON)
 
-                        Assert.assertTrue(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_HEADER)
-                                .contains(AUConstants.BANK_CUSTOMER_BASIC_READ_INDIVIDUAL))
-                        authWebDriver.clickButtonXpath(AUPageObjects.LBL_PERMISSION_HEADER)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_1),
-                                AUConstants.LBL_NAME)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_2),
-                                AUConstants.LBL_OCCUPATION)
+                        authWebDriver.clickButtonXpath(AUPageObjects.SINGLE_ACCOUNT_XPATH)
+                        authWebDriver.clickButtonXpath(AUPageObjects.CONSENT_NEXT)
+
+                        String header = AUConstants.BANK_CUSTOMER_BASIC_READ_INDIVIDUAL
+                        assert authWebDriver.isElementDisplayed(AUPageObjects.getScopeGroupHeaderXpath(header))
+
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 1)), AUConstants.LBL_NAME)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 2)), AUConstants.LBL_OCCUPATION)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 3)), AUConstants.LBL_PHONE)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 4)), AUConstants.LBL_EMAIL_ADDRESS)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 5)), AUConstants.LBL_MAIL_ADDRESS)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 6)), AUConstants.LBL_RESIDENTIAL_ADDRESS)
                     } else {
                         assert authWebDriver.isElementDisplayed(AUTestUtil.getSingleAccountXPath())
                         log.info("Profile Selection is Disabled")
@@ -144,9 +155,10 @@ class ConsentAuthFlowValidationTests extends AUTest {
                 .execute()
     }
 
-    // TODO: Enable after implementing customer language rendering for individual and business consumer profiles
-    @Test (enabled = false)
+    @Test
     void "CDS-544_Verify customer language in consent page for business consumer"() {
+
+        auConfiguration.setPsuNumber(0)
 
         List<AUAccountScope> scopes = [AUAccountScope.BANK_CUSTOMER_DETAIL_READ]
 
@@ -165,26 +177,34 @@ class ConsentAuthFlowValidationTests extends AUTest {
                         authWebDriver.selectOption(AUPageObjects.ORGANIZATION_A_PROFILE_SELECTION)
                         authWebDriver.clickButtonXpath(AUPageObjects.PROFILE_SELECTION_NEXT_BUTTON)
 
-                        Assert.assertTrue(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_HEADER)
-                                .contains(AUConstants.BANK_CUSTOMER_BASIC_READ))
+                        authWebDriver.clickButtonXpath(AUPageObjects.CHK_ORG_A_BUSINESS_ACCOUNT_1)
+                        authWebDriver.clickButtonXpath(AUPageObjects.CONSENT_NEXT)
 
-                        authWebDriver.clickButtonXpath(AUPageObjects.LBL_PERMISSION_HEADER)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_1),
-                                AUConstants.LBL_AGENT_NAME_AND_ROLE)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_2),
-                                AUConstants.LBL_ORGANISATION_NAME)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_3),
-                                AUConstants.LBL_ORGANISATION_NUMBER)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_4),
-                                AUConstants.LBL_CHARITY_STATUS)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_5),
-                                AUConstants.LBL_ESTABLISHMENT_DATE)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_6),
-                                AUConstants.LBL_INDUSTRY)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_7),
-                                AUConstants.LBL_ORGANISATION_TYPE)
-                        Assert.assertEquals(authWebDriver.getAttributeText(AUPageObjects.LBL_PERMISSION_LIST_ITEM_8),
-                                AUConstants.LBL_COUNTRY_OF_REGISTRATION)
+                        String header = AUConstants.BANK_CUSTOMER_BASIC_READ
+                        assert authWebDriver.isElementDisplayed(AUPageObjects.getScopeGroupHeaderXpath(header))
+
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 1)), AUConstants.LBL_AGENT_NAME_AND_ROLE)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 2)), AUConstants.LBL_ORGANISATION_NAME)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 3)), AUConstants.LBL_ORGANISATION_NUMBER)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 4)), AUConstants.LBL_CHARITY_STATUS)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 5)), AUConstants.LBL_ESTABLISHMENT_DATE)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 6)), AUConstants.LBL_INDUSTRY)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 7)), AUConstants.LBL_ORGANISATION_TYPE)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 8)), AUConstants.LBL_COUNTRY_OF_REGISTRATION)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 9)), AUConstants.LBL_ORGANISATION_ADDRESS)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 10)), AUConstants.LBL_MAIL_ADDRESS)
+                        Assert.assertEquals(authWebDriver.getAttributeText(
+                                AUPageObjects.getScopeGroupListItemXpath(header, 11)), AUConstants.LBL_PHONE_NUMBER)
                     } else {
                         assert authWebDriver.isElementDisplayed(AUTestUtil.getSingleAccountXPath())
                         log.info("Profile Selection is Disabled")
@@ -386,7 +406,7 @@ class ConsentAuthFlowValidationTests extends AUTest {
     @Test
     void "CDS-510_Verify a non-NR user does not see any business profile in the consent flow"() {
 
-        auConfiguration.setPsuNumber(0)
+        auConfiguration.setPsuNumber(1)
 
         response = auAuthorisationBuilder.doPushAuthorisationRequest(scopes, AUConstants.DEFAULT_SHARING_DURATION,
                 true, "")
@@ -414,7 +434,7 @@ class ConsentAuthFlowValidationTests extends AUTest {
     @Test (priority = 1)
     void "CDS-512_Verify a Consent Authorization Flow with non NR"() {
 
-        auConfiguration.setPsuNumber(0)
+        auConfiguration.setPsuNumber(1)
 
         //Get Authorisation URL
         response = auAuthorisationBuilder.doPushAuthorisationRequest(scopes, AUConstants.DEFAULT_SHARING_DURATION,

--- a/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/secondaryUser/CeasingSecondaryUserConsentFlowTest.groovy
+++ b/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/secondaryUser/CeasingSecondaryUserConsentFlowTest.groovy
@@ -49,13 +49,13 @@ class CeasingSecondaryUserConsentFlowTest extends AUTest {
     void "Pre Execution Step"() {
 
         auConfiguration.setTppNumber(0)
-        auConfiguration.setPsuNumber(0)
+        auConfiguration.setPsuNumber(1)
         clientId = auConfiguration.getAppInfoClientID()
         //Get Sharable Account List and Secondary User with Authorize Permission
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts())
 
         accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        userId = auConfiguration.getUserPSUName(0)
+        userId = auConfiguration.getUserPSUName(1)
         clientHeader = "${Base64.encoder.encodeToString(getCDSClient().getBytes(Charset.defaultCharset()))}"
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.ACTIVE)
@@ -360,5 +360,4 @@ class CeasingSecondaryUserConsentFlowTest extends AUTest {
                     authWebDriver.clickButtonXpath(AUPageObjects.CONSENT_CONFIRM_XPATH)
                 }.execute()
     }
-
 }

--- a/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/secondaryUser/CeasingSecondaryUserManagementTest.groovy
+++ b/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/secondaryUser/CeasingSecondaryUserManagementTest.groovy
@@ -55,7 +55,7 @@ class CeasingSecondaryUserManagementTest extends AUTest {
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts())
 
         accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        userId = auConfiguration.getUserPSUName()
+        userId = auConfiguration.getUserPSUName(1)
 
         //Give Secondary User Instruction Permission
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.ACTIVE)

--- a/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/secondaryUser/SecondaryUserInstructionsAuthorisationTest.groovy
+++ b/integration-test-suite/cds-toolkit-integration-test/src/test/groovy/org/wso2/cds/keymanager/test/secondaryUser/SecondaryUserInstructionsAuthorisationTest.groovy
@@ -43,13 +43,13 @@ class SecondaryUserInstructionsAuthorisationTest extends AUTest {
     void "Provide User Permissions"() {
 
         auConfiguration.setTppNumber(0)
-        auConfiguration.setPsuNumber(0)
+        auConfiguration.setPsuNumber(1)
         clientId = auConfiguration.getAppInfoClientID()
         //Get Sharable Account List and Secondary User with Authorize Permission
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts())
 
         accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        userId = auConfiguration.getUserPSUName()
+        userId = auConfiguration.getUserPSUName(1)
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.ACTIVE)
         Assert.assertEquals(updateResponse.statusCode(), AUConstants.OK)
@@ -322,7 +322,7 @@ class SecondaryUserInstructionsAuthorisationTest extends AUTest {
         // To make sure secondary account 1 is active
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts(), true)
         String accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        String userId = auConfiguration.getUserPSUName(0)
+        String userId = auConfiguration.getUserPSUName(1)
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.ACTIVE)
         Assert.assertEquals(updateResponse.statusCode(), AUConstants.OK)
@@ -360,7 +360,7 @@ class SecondaryUserInstructionsAuthorisationTest extends AUTest {
         //Provide secondary user instruction permissions for individual account
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts(), true)
         String accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        String userId = auConfiguration.getUserPSUName(0)
+        String userId = auConfiguration.getUserPSUName(1)
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.ACTIVE)
         Assert.assertEquals(updateResponse.statusCode(), AUConstants.OK)
@@ -426,12 +426,12 @@ class SecondaryUserInstructionsAuthorisationTest extends AUTest {
         //Inactive secondary user instruction permissions for individual account
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts(), true)
         String accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        String userId = auConfiguration.getUserPSUName(0)
+        String userId = auConfiguration.getUserPSUName(1)
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.INACTIVE)
         Assert.assertEquals(updateResponse.statusCode(), AUConstants.OK)
 
-        auConfiguration.setPsuNumber(0)
+        auConfiguration.setPsuNumber(1)
 
         //Consent Authorisation
         response = auAuthorisationBuilder.doPushAuthorisationRequest(scopes, AUConstants.DEFAULT_SHARING_DURATION,
@@ -459,7 +459,7 @@ class SecondaryUserInstructionsAuthorisationTest extends AUTest {
         //Inactive secondary user instruction permissions for joint account
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts(), false)
         String accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        String userId = auConfiguration.getUserPSUName(0)
+        String userId = auConfiguration.getUserPSUName(1)
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.INACTIVE)
         Assert.assertEquals(updateResponse.statusCode(), AUConstants.OK)
@@ -490,7 +490,7 @@ class SecondaryUserInstructionsAuthorisationTest extends AUTest {
         //Inactive secondary user instruction permissions for individual account
         shareableElements = AUTestUtil.getSecondaryUserDetails(getSharableBankAccounts(), true)
         String accountID =  shareableElements[AUConstants.PARAM_ACCOUNT_ID]
-        String userId = auConfiguration.getUserPSUName(0)
+        String userId = auConfiguration.getUserPSUName(1)
 
         def updateResponse = updateSecondaryUserInstructionPermission(accountID, userId, AUConstants.INACTIVE)
         Assert.assertEquals(updateResponse.statusCode(), AUConstants.OK)

--- a/integration-test-suite/cds-toolkit-test-framework/src/main/groovy/org/wso2/cds/test/framework/constant/AUConstants.groovy
+++ b/integration-test-suite/cds-toolkit-test-framework/src/main/groovy/org/wso2/cds/test/framework/constant/AUConstants.groovy
@@ -125,7 +125,7 @@ class AUConstants extends Constants {
     public static final String BANK_TRANSACTION_READ = "Transaction details"
     public static final String BANK_PAYEES_READ = "Saved payees"
     public static final String BANK_REGULAR_PAYMENTS_READ = "Direct debits and scheduled payments"
-    public static final String BANK_CUSTOMER_BASIC_READ_INDIVIDUAL = "Name and occupation"
+    public static final String BANK_CUSTOMER_BASIC_READ_INDIVIDUAL = "Name, occupation, contact details"
     public static final String BANK_CUSTOMER_BASIC_DETAIL_INDIVIDUAL = "Name, occupation, contact details ‡"
 
     public static final String LBL_OTP_TIMEOUT = "//div[@id='otpTimeout']"
@@ -622,6 +622,4 @@ class AUConstants extends Constants {
     public static final String CONTENT_TYPE_APPLICATION_SCIM_JSON = "application/scim+json"
     public static final String SUBSCRIBER_ROLE = "Internal/subscriber"
     public static final String PUBLISHER_ROLE = "Internal/publisher"
-
 }
-

--- a/integration-test-suite/cds-toolkit-test-framework/src/main/groovy/org/wso2/cds/test/framework/constant/AUPageObjects.groovy
+++ b/integration-test-suite/cds-toolkit-test-framework/src/main/groovy/org/wso2/cds/test/framework/constant/AUPageObjects.groovy
@@ -18,8 +18,6 @@
 
 package org.wso2.cds.test.framework.constant
 
-import org.apache.commons.lang3.StringUtils
-
 /**
  * Class for keep automation Page objects
  */
@@ -62,6 +60,32 @@ class AUPageObjects {
     public static String LBL_PERMISSION_LIST_ITEM_10 = "//h4[text()='Data requested:']/following-sibling::div//ul[@class='scopes-list padding']//li[10]"
     public static String LBL_PERMISSION_LIST_ITEM_11 = "//h4[text()='Data requested:']/following-sibling::div//ul[@class='scopes-list padding']//li[11]"
     public static String LBL_PERMISSION_HEADER = "//*[@class='padding']//button"
+
+    /**
+     * Build the XPath for a scope group's header label (the bold title of a
+     * "Data requested" group on the consent page, e.g. "Name, occupation, contact details").
+     *
+     * @param header the exact heading text shown in the {@code <b>} element
+     * @return XPath locating the {@code <b>} heading element
+     */
+    static String getScopeGroupHeaderXpath(String header) {
+        return "//div[contains(@style,'border:1px solid')]/b[normalize-space(text())='${header}']"
+    }
+
+    /**
+     * Build the XPath for a single list item under a scope group on the consent page.
+     * The new consent UI renders each scope group as a flat
+     * {@code <div><b>Header</b><ul class="scopes-list ..."><li>...</li></ul></div>}
+     * (no accordion / no expand button), so items are resolved relative to the heading text.
+     *
+     * @param header the exact group heading text (e.g. "Name, occupation, contact details")
+     * @param index  1-based index of the {@code <li>} within the group's scopes list
+     * @return XPath locating the requested list item
+     */
+    static String getScopeGroupListItemXpath(String header, int index) {
+        return "//div[contains(@style,'border:1px solid')]/b[normalize-space(text())='${header}']" +
+                "/following-sibling::ul[contains(@class,'scopes-list')]/li[${index}]"
+    }
     public static String LBL_SECONDARY_ACCOUNT_INDICATION= "//button[@id='secondary_account']/span[contains(text(),'New')]"
 
     public static String LBL_AUTHORISED_STATUS = "//div[@id='heading0acc']//div[@class='p1 consent-status ml-3 ml-auto align-self-center']"

--- a/integration-test-suite/cds-toolkit-test-framework/src/main/resources/SampleTestConfiguration.xml
+++ b/integration-test-suite/cds-toolkit-test-framework/src/main/resources/SampleTestConfiguration.xml
@@ -243,7 +243,7 @@
         <!-- Common PSU Info -->
         <PSUInfo>
             <Credentials>
-                <User>user1@wso2.com</User>
+                <User>nominatedUser1@wso2.com</User>
                 <Password>wso2123</Password>
             </Credentials>
         </PSUInfo>


### PR DESCRIPTION
## Re-enable customer language consent tests against new flat consent page and psu configuration fixes

> The CDS-543 and CDS-544 consent-page customer-language tests were
previously disabled because the auth UI rendered scope groups as an
accordion (clickable button + hidden panel). The new consent page
renders each scope group as a flat <div><b>Header</b><ul><li>...</li></ul></div>
block with all items visible by default, so the old locators
(LBL_PERMISSION_HEADER button + accordion-id list-item XPaths) and
the click-to-expand step no longer apply. 


------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

